### PR TITLE
Make Travis-CI successfully download and use CMake 2.8.12. .travis.yml sections reorganized.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ before_install:
 
 install:
  - sudo apt-get install -qq qt5-default libqt5svg5-dev > output
-# - wget http://www.cmake.org/files/v2.8/cmake-2.8.12.1-Linux-i386.tar.gz
-# - tar xzf cmake-2.8.12.1-Linux-i386.tar.gz
-# - wget http://www.cmake.org/files/v2.8/cmake-2.8.12.1-Linux-i386.sh -O - | sh --prefix=/usr/local/ --exclude-subdir --skip-license
 # 32 bit compatibility (since CMake is a 32 bit bin)
- - sudo apt-get install libc6:i386
+ - sudo apt-get install -qq libc6:i386
 # Install CMake bin (32 bit)
  - wget -P /tmp http://www.cmake.org/files/v2.8/cmake-2.8.12.1-Linux-i386.sh
  - chmod +rx /tmp/cmake-2.8.12.1-Linux-i386.sh
@@ -23,7 +20,6 @@ before_script:
  - cd viewer
  - mkdir build
  - cd build
-# - "`pwd`/cmake-2.8.12.1-Linux-i386/bin/cmake ../"
  - cmake ../
 
 script: make


### PR DESCRIPTION
Travis-CI Linux boxes are 64 bit, and 32 bit comptatibility libs are not installed. Fixed by installing libc6:i386 before running CMake.
Also reorganized the .travis.yml with before_install, install and before_script steps.
