### PR TITLE
Drawing of set of boxes, union of boxes and lines + various improvements

### DIFF
--- a/client-api/C++/examples/all_commands.cpp
+++ b/client-api/C++/examples/all_commands.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <ctime>
 #include <vector>
+#include <cmath>
 
 // Utility macro to log executed instructions on terminal
 #define VIBES_TEST(instruction) std::cout << "[l." << __LINE__ << "] " << #instruction << "..."; instruction; std::cout << " OK" << std::endl;
@@ -26,19 +27,58 @@ int main()
 
     cout << "Figure creation function" << endl;
     VIBES_TEST( vibes::figure() );
-    // Megatest Wayne!!!
-    for (int i=0; i<10000; ++i)
+
+    cout << "Megatest Wayne!" << std::endl;
     {
-        std::vector<double> bounds(4*2);
-        for (int j=0; j<bounds.size(); j++)
+        const int nbBoxesMegaTest = 10000;
+        const int dimBoxesMegaTest = 4;
+
+        std::vector< std::vector<double> > boxes_bounds;
+        std::vector<double> box_bounds(dimBoxesMegaTest*2);
+        for (int i=0; i<nbBoxesMegaTest; ++i)
         {
-            if (! (j%2))
-                bounds[j] = 25.0 * rand() / RAND_MAX;
-            else
-                bounds[j] = bounds[j-1] + 5.0 * rand() / RAND_MAX;
+            for (int j=0; j<box_bounds.size(); j++)
+            {
+                if (! (j%2))
+                    box_bounds[j] = 25.0 * rand() / RAND_MAX;
+                else
+                    box_bounds[j] = box_bounds[j-1] + 5.0 * rand() / RAND_MAX;
+            }
+            boxes_bounds.push_back(box_bounds);
         }
-        vibes::drawBox(bounds,"lightGray");
+        VIBES_TEST( vibes::figure("Megatest with boxes") );
+        VIBES_TEST( vibes::drawBoxes(boxes_bounds,"darkYellow") );
+
+        VIBES_TEST( vibes::figure("Megatest with boxes union") );
+        VIBES_TEST( vibes::drawBoxesUnion(boxes_bounds,"darkGreen") );
     }
+
+    cout << "Plotting y=sin(x) and y=cos(x)" << std::endl;
+    {
+        const int nbPts = 1000;
+        const double xStep = 0.01;
+
+        std::vector< double > vect_x;
+        std::vector< double > vect_y;
+        std::vector< std::vector<double> > points;
+        std::vector<double> point(3);
+        for (int i=0; i<nbPts; ++i)
+        {
+            const double x = xStep * i;
+            point[0] = x;
+            point[1] = sin(x);
+            point[2] = cos(x);
+            points.push_back(point);
+            vect_x.push_back(x);
+            vect_y.push_back(cos(x));
+        }
+        VIBES_TEST( vibes::figure("sin and cos") );
+        VIBES_TEST( vibes::drawLine(points,"red") );
+        VIBES_TEST( vibes::drawLine(vect_x,vect_y,"blue") );
+
+        VIBES_TEST( vibes::axisAuto() );
+    }
+
 
     VIBES_TEST( vibes::figure("figureTest") );
 
@@ -67,7 +107,23 @@ int main()
 
     VIBES_TEST( vibes::drawEllipse(0,-4.75,4,0.25,0.0, "darkGray") );
 
-
+    cout << "drawBoxes with vector of vector of bounds" << std::endl;
+    {
+        std::vector< std::vector<double> > boxes_bounds;
+        std::vector<double> box_bounds(4*2);
+        for (int i=0; i<10; ++i)
+        {
+            for (int j=0; j<box_bounds.size(); j++)
+            {
+                if (! (j%2))
+                    box_bounds[j] = pow(i, 1.0 / ((j/2)+1));
+                else
+                    box_bounds[j] = pow(i+1.0, 1.0 / ((j/2)+1));;
+            }
+            boxes_bounds.push_back(box_bounds);
+        }
+        VIBES_TEST( vibes::drawBoxes(boxes_bounds,"yellow") );
+    }
 
     VIBES_TEST( vibes::axisAuto() );
     //  VIBES_TEST( vibes::axisLimits(-1,1, -3,2) );

--- a/client-api/C++/src/vibes.cpp
+++ b/client-api/C++/src/vibes.cpp
@@ -243,4 +243,60 @@ namespace vibes
       fputs(Value(msg).toJSONString().append("\n\n").c_str(), channel);
       fflush(channel);
   }
+
+  void drawBoxes(const std::vector<std::vector<double> > &bounds, Params params)
+  {
+     Params msg;
+     msg["action"] = "draw";
+     msg["figure"] = params.pop("figure",current_fig);
+     msg["shape"] = (params, "type", "boxes",
+                             "bounds", bounds);
+
+     fputs(Value(msg).toJSONString().append("\n\n").c_str(), channel);
+     fflush(channel);
+  }
+
+  void drawBoxesUnion(const std::vector<std::vector<double> > &bounds, Params params)
+  {
+     Params msg;
+     msg["action"] = "draw";
+     msg["figure"] = params.pop("figure",current_fig);
+     msg["shape"] = (params, "type", "boxes union",
+                             "bounds", bounds);
+
+     fputs(Value(msg).toJSONString().append("\n\n").c_str(), channel);
+     fflush(channel);
+  }
+
+  void drawLine(const std::vector<std::vector<double> > &points, Params params)
+  {
+     Params msg;
+     msg["action"] = "draw";
+     msg["figure"] = params.pop("figure",current_fig);
+     msg["shape"] = (params, "type", "line",
+                             "points", points);
+
+     fputs(Value(msg).toJSONString().append("\n\n").c_str(), channel);
+     fflush(channel);
+  }
+
+  void drawLine(const std::vector<double> &x, const std::vector<double> &y, Params params)
+  {
+     // Reshape x and y into a vector of points
+     std::vector<Value> points;
+     std::vector<double>::const_iterator itx = x.begin();
+     std::vector<double>::const_iterator ity = y.begin();
+     while (itx != x.end() && ity != y.end()) {
+        points.push_back( (Vec2d){*itx++,*ity++} );
+     }
+     // Send message
+     Params msg;
+     msg["action"] = "draw";
+     msg["figure"] = params.pop("figure",current_fig);
+     msg["shape"] = (params, "type", "line",
+                             "points", points);
+
+     fputs(Value(msg).toJSONString().append("\n\n").c_str(), channel);
+     fflush(channel);
+  }
 }

--- a/client-api/C++/src/vibes.h
+++ b/client-api/C++/src/vibes.h
@@ -62,6 +62,7 @@ namespace vibes {class Params;
         Value(const std::string &s) : _string(s), _type(vt_string) {}
         Value(const char *s) : _string(s), _type(vt_string) {}
         Value(const std::vector<Value> &a) : _array(a), _type(vt_array) {}
+        template <typename T> Value(const std::vector<T> &v) : _array(v.begin(),v.end()), _type(vt_array) {}
         /*explicit */Value(const Params &p) : _object(&p), _type(vt_object) {}
         bool empty() {return (_type == vt_none);}
         std::string toJSONString() const;
@@ -180,6 +181,12 @@ namespace vibes {class Params;
                                                  const double &,K/*=3.0*/)
   VIBES_FUNC_COLOR_PARAM_3(drawCircle,const double &,cx, const double &,cy, const double &,r)
 
+  VIBES_FUNC_COLOR_PARAM_1(drawBoxes,const std::vector< std::vector<double> > &,bounds)
+  VIBES_FUNC_COLOR_PARAM_1(drawBoxesUnion,const std::vector< std::vector<double> > &,bounds)
+
+  VIBES_FUNC_COLOR_PARAM_1(drawLine,const std::vector< std::vector<double> > &,points)
+  VIBES_FUNC_COLOR_PARAM_2(drawLine,const std::vector<double> &,x, const std::vector<double> &,y)
+
   // Ibex enabled functions
   #ifdef _IBEX_INTERVAL_H_
     VIBES_FUNC_COLOR_PARAM_2(drawBox,const ibex::Interval &,x, const ibex::Interval &,y)
@@ -203,6 +210,7 @@ namespace vibes {class Params;
     }
   #endif //#ifdef _IBEX_INTERVAL_H_
   #ifdef __IBEX_INTERVAL_VECTOR_H__
+  /// \todo N-dimensionanl Ibex Inteval vector support
     inline void drawBox(const ibex::IntervalVector &box, Params params) {
         drawBox(box[0], box[1], params);
     }

--- a/viewer/vibesgraphicsitem.h
+++ b/viewer/vibesgraphicsitem.h
@@ -3,7 +3,9 @@
 
 #include <QGraphicsItem>
 #include <QJsonObject>
-#include <QBitArray>
+#include <QJsonValue>
+
+//#include <QBitArray>
 
 // VibesDefaults includes
 #include <QHash>
@@ -16,7 +18,7 @@ class VibesDefaults {
 public:
     static const VibesDefaults & instance() { return _instance; }
     const QBrush brush(const QString & name = QString()) const { return _brushes[name]; }
-    const QPen pen() const { return _pen; }
+    const QPen pen(const QString & name = QString()) const { return _pen; }
 private:
     VibesDefaults();
     static VibesDefaults _instance;
@@ -27,40 +29,72 @@ private:
 
 class VibesGraphicsItem
 {
+    // Pointer to the QGraphicsItem object. Used for casting.
+    QGraphicsItem * _qGraphicsItem;
 public:
     enum { VibesGraphicsItemType = QGraphicsItem::UserType,
+           // Primitive types
            VibesGraphicsBoxType,
-           VibesGraphicsBoxesType,
            VibesGraphicsEllipseType,
-           VibesGraphicsLastType // Do not remove! Signals the end of VibesGraphicsItem types
+           // List based types
+           //VibesGraphicsPointsType,
+           VibesGraphicsLineType,
+           VibesGraphicsBoxesType,
+           VibesGraphicsBoxesUnionType,
+           // Do not remove the following value! It signals the end of VibesGraphicsItem types
+           VibesGraphicsLastType
          };
-    VibesGraphicsItem();
+    // Constructor
+    VibesGraphicsItem(QGraphicsItem * qGraphicsItem);
+    // Destructor (virtual)
+    virtual ~VibesGraphicsItem() {}
+
     bool setJson(const QJsonObject &json, int dimX=0, int dimY=1);
     const QJsonObject & json() const { return _json; }
     bool existsInProj(int dimX, int dimY) const { return hasDim(dimX) && hasDim(dimY); }
     bool setProj(int dimX, int dimY);
     int dimension() const { return maxDim(); }
+
+    operator QGraphicsItem& () { Q_ASSERT(_qGraphicsItem!=0); return *_qGraphicsItem; }
+    operator const QGraphicsItem& () const { Q_ASSERT(_qGraphicsItem!=0); return *_qGraphicsItem; }
+
+    static VibesGraphicsItem *newWithType(const QString type);
+
 protected:
     virtual bool parseJson(const QJsonObject &json) = 0;
     virtual bool computeProjection(int dimX=0, int dimY=1) = 0;
     virtual bool hasDim(int n) const { return n>=0 && n<_nbDim; }
     virtual int maxDim() const { return _nbDim; }
+    // Utility
+    static bool isJsonMatrix(const QJsonValue json, int &nbRows, int &nbCols);
+    static bool isJsonMatrix(const QJsonValue json) { int r,c; return isJsonMatrix(json, r, c); }
 protected:
     QJsonObject _json;
     int _nbDim;
 };
 
-
-inline VibesGraphicsItem * vibesgraphicsitem_cast(QGraphicsItem *item)
+// Specialization of qgraphicsitem_cast to VibesGraphicsItem* base class (uses dynamic_cast)
+template<> inline VibesGraphicsItem * qgraphicsitem_cast(QGraphicsItem *item)
 {
     return (item && item->type() >= VibesGraphicsItem::VibesGraphicsItemType
             && item->type() < VibesGraphicsItem::VibesGraphicsLastType) ? dynamic_cast<VibesGraphicsItem*>(item) : 0;
 }
 
-inline const VibesGraphicsItem * vibesgraphicsitem_cast(const QGraphicsItem *item)
+template<> inline const VibesGraphicsItem * qgraphicsitem_cast(const QGraphicsItem *item)
 {
     return (item && item->type() >= VibesGraphicsItem::VibesGraphicsItemType
             && item->type() < VibesGraphicsItem::VibesGraphicsLastType) ? dynamic_cast<const VibesGraphicsItem*>(item) : 0;
+}
+
+// Provides a cast to GraphicsItem classes from VibesGraphicsItem base class, without using dynamic_cast.
+template <class T> inline T vibesgraphicsitem_cast(VibesGraphicsItem *item)
+{
+    return item ? qgraphicsitem_cast<T>(&(static_cast<QGraphicsItem&>(*item))) : 0;
+}
+
+template <class T> inline const T vibesgraphicsitem_cast(const VibesGraphicsItem *item)
+{
+    return item ? qgraphicsitem_cast<T>(&(static_cast<const QGraphicsItem&>(*item))) : 0;
 }
 
 
@@ -70,8 +104,8 @@ inline const VibesGraphicsItem * vibesgraphicsitem_cast(const QGraphicsItem *ite
     int type() const { return Type; }
 // A macro for defining the constructor of VibesGraphicsItem subclasses
 #define VIBES_GRAPHICS_ITEM_CTOR_DECL(class_name, base_class) \
-    class_name(QGraphicsItem * parent = 0) : base_class(parent), VibesGraphicsItem() {} \
-    class_name(const QJsonObject &json, QGraphicsItem * parent = 0) : base_class(parent), VibesGraphicsItem() { setJson(json); }
+    class_name(QGraphicsItem * parent = 0) : base_class(parent), VibesGraphicsItem(this) {} \
+    class_name(const QJsonObject &json, QGraphicsItem * parent = 0) : base_class(parent), VibesGraphicsItem(this) { setJson(json); }
 // A macro for defining VibesGraphicsItem subclasses
 #define VIBES_GRAPHICS_ITEM(class_name, base_class) \
 public: \
@@ -91,9 +125,19 @@ protected:
 
 /// A set of boxes
 
-class VibesGraphicsBoxes : public QGraphicsPathItem, public VibesGraphicsItem
+class VibesGraphicsBoxes : public QGraphicsItemGroup, public VibesGraphicsItem
 {
-    VIBES_GRAPHICS_ITEM(VibesGraphicsBoxes, QGraphicsPathItem)
+    VIBES_GRAPHICS_ITEM(VibesGraphicsBoxes, QGraphicsItemGroup)
+protected:
+    bool parseJson(const QJsonObject &json);
+    bool computeProjection(int dimX, int dimY);
+};
+
+/// The union of a set of boxes
+
+class VibesGraphicsBoxesUnion : public QGraphicsPathItem, public VibesGraphicsItem
+{
+    VIBES_GRAPHICS_ITEM(VibesGraphicsBoxesUnion, QGraphicsPathItem)
 protected:
     bool parseJson(const QJsonObject &json);
     bool computeProjection(int dimX, int dimY);
@@ -110,6 +154,17 @@ protected:
     bool computeProjection(int dimX, int dimY);
     void axisAngleFromCovarianceK(const double &sxx, const double &syy, const double &sxy, const double &k,
                                   double &wx, double &wy, double &angle);
+};
+
+
+/// A line (defined by a set of points)
+
+class VibesGraphicsLine : public QGraphicsPathItem, public VibesGraphicsItem
+{
+    VIBES_GRAPHICS_ITEM(VibesGraphicsLine, QGraphicsPathItem)
+protected:
+    bool parseJson(const QJsonObject &json);
+    bool computeProjection(int dimX, int dimY);
 };
 
 #endif // VIBESGRAPHICSITEM_H

--- a/viewer/vibesscene2d.h
+++ b/viewer/vibesscene2d.h
@@ -2,7 +2,8 @@
 #define VIBESSCENE2D_H
 
 #include <QGraphicsScene>
-#include <QJsonObject>
+class QJsonObject;
+class VibesGraphicsItem;
 
 class VibesScene2D : public QGraphicsScene
 {
@@ -12,7 +13,9 @@ class VibesScene2D : public QGraphicsScene
     int _nbDim;
 public:
     explicit VibesScene2D(QObject *parent = 0);
-    QGraphicsItem * addJsonShapeItem(const QJsonObject &shape);
+    VibesGraphicsItem *addJsonShapeItem(const QJsonObject &shape);
+
+    void addVibesItem(VibesGraphicsItem *item);
 
     const int nbDim() const { return _nbDim; }
     const int dimX() const { return _dimX; }


### PR DESCRIPTION
- drawBoxes: draw a set of boxes from a vector of boxes (vector of
  bounds)
- drawBoxesUnion: same input as drawBoxes, but computes the union of
  boxes before displaying
- drawLine: draw a line from a vector of points (vector of coordinates),
  of from two vectors of x an y coordinates. Fixes #12
- Moved VibesGraphicsItem factory from VibesScene2D to a static
  VibesGraphicsItem function.
- Modified cast functions for VibesGraphicsItem\* <-> QGraphicsItem*
