### PR TITLE
Add custom colors handling.

### DIFF
--- a/client-api/C++/examples/all_commands.cpp
+++ b/client-api/C++/examples/all_commands.cpp
@@ -42,6 +42,11 @@ int main()
     //VIBES_TEST( vibes::clearGroup("group") );
     VIBES_TEST( vibes::clearFigure() );
 
+    std::cout << "Testing Vibes Custom Colors ans Transparency" << std::endl;
+    VIBES_TEST( vibes::newFigure("CustomColor") );
+    VIBES_TEST( vibes::drawBox(-1,0,-2,-1, "[red]"));
+    VIBES_TEST( vibes::drawBox(0,1,0,1, "#FF3300AA[#00345678]"));
+    VIBES_TEST( vibes::drawBox(0.5,1.5,0.5,1.5, "#FF0022AA[#FF0056AA]"));
 
     cout << "Megatest Wayne!" << std::endl;
     {
@@ -269,5 +274,8 @@ int main()
 
     printf ("Classic draw took %d clicks (%f seconds).\n",t1,((float)t1)/CLOCKS_PER_SEC);
     printf ("Param based draw took %d clicks (%f seconds).\n",t2,((float)t2)/CLOCKS_PER_SEC);*/
+
+
+    
     return 0;
 }

--- a/viewer/vibesgraphicsitem.h
+++ b/viewer/vibesgraphicsitem.h
@@ -17,9 +17,32 @@ class VibesDefaults {
     QHash<QString, QBrush> _brushes;
     QHash<QString, QPen> _pens;
 public:
-    static const VibesDefaults & instance() { return _instance; }
-    const QBrush brush(const QString & name = QString()) const { return _brushes[name]; }
-    const QPen pen(const QString & name = QString()) const { return _pens[name]; }
+    static VibesDefaults & instance() { return _instance; }
+
+    const QColor parseColorName(const QString& name){
+        Q_ASSERT(name.size() == 7 || name.size() == 9);
+        // Suported format #RRGGBB and #RRGGBBAA
+        QColor color;
+        color.setNamedColor(name.mid(0,7));
+        // if len of name > 7 the 2 last caracters are the alpha value
+        if(name.size() > 7){
+            color.setAlpha(name.mid(7,2).toUInt(0,16));
+        }
+        return color;
+    }
+    const QBrush brush(const QString & name = QString()) {
+        if( !_brushes.contains(name)){
+            _brushes[name] = QBrush(parseColorName(name));
+        }
+        return _brushes[name];
+    }
+
+    const QPen pen(const QString & name = QString()) {
+        if( !_pens.contains(name)){
+            _pens[name] = QPen(parseColorName(name),0);
+        }
+        return _pens[name];
+    }
 private:
     VibesDefaults();
     static VibesDefaults _instance;


### PR DESCRIPTION
Can use custom colors with transparency in the form #RRGGBB or #RRGGBBAA instead of predefined colors.
See all_commands.cpp to see example.