### PR TITLE
Colors

### DIFF
--- a/client-api/C++/examples/CMakeLists.txt
+++ b/client-api/C++/examples/CMakeLists.txt
@@ -17,6 +17,8 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_LIST_DIR}/../src/)
 
 ADD_EXECUTABLE(all_commands all_commands.cpp ${vibes_SOURCES})
 
+ADD_EXECUTABLE(newmain newmain.cpp ${vibes_SOURCES})
+
 INCLUDE_DIRECTORIES(interval)
 
 ADD_EXECUTABLE(sivia_simple sivia_simple.cpp ${interval_SOURCES} ${vibes_SOURCES})

--- a/client-api/C++/examples/CMakeLists.txt
+++ b/client-api/C++/examples/CMakeLists.txt
@@ -17,8 +17,6 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_LIST_DIR}/../src/)
 
 ADD_EXECUTABLE(all_commands all_commands.cpp ${vibes_SOURCES})
 
-ADD_EXECUTABLE(newmain newmain.cpp ${vibes_SOURCES})
-
 INCLUDE_DIRECTORIES(interval)
 
 ADD_EXECUTABLE(sivia_simple sivia_simple.cpp ${interval_SOURCES} ${vibes_SOURCES})

--- a/client-api/C++/examples/all_commands.cpp
+++ b/client-api/C++/examples/all_commands.cpp
@@ -142,6 +142,44 @@ int main()
         VIBES_TEST( vibes::axisLabels(labels) );
     }
 
+    cout << "plotting y=abs(cos(x)), y=abs(sin(x)), y=abs(sin(sin(x)))"<<endl;
+    {
+        const int nbPts = 1000;
+        const double xStep = 0.01;
+
+        std::vector< std::vector<double> > points;
+        std::vector<double> point(2);
+        std::vector< double > vect_x2;
+        std::vector< double > vect_y2;
+        
+        std::vector< double > vect_x3;
+        std::vector< double > vect_y3;
+        for (int i=0; i<nbPts; ++i)
+        {
+            const double x = xStep * i;
+            point[0] = x;
+            point[1] = fabs(cos(x));
+            points.push_back(point);
+            
+            vect_x2.push_back(x);
+            vect_y2.push_back(fabs(sin(x)));
+            
+            vect_x3.push_back(x);
+            vect_y3.push_back(sin(sin(x)));
+        }
+        VIBES_TEST( vibes::newFigure("abs(cos), abs(sin), sin(sin)") );
+        VIBES_TEST( vibes::drawLine(points,"tomato-..") );
+        VIBES_TEST(vibes::drawLine(vect_x2,vect_y2,vibesParams("LineWidth",0.07,"LineStyle",":","EdgeColor",(vibes::RGBA){255,255,255,255})));
+        VIBES_TEST(vibes::drawLine(vect_x3,vect_y3,vibesParams("LineWidth",0.0042,"LineStyle","--","EdgeColor",(vibes::RGBA){0,128,128,108})));
+
+        VIBES_TEST( vibes::axisAuto() );
+
+        VIBES_TEST( vibes::setFigureProperties("abs(cos)",
+                                                vibesParams("x",0,"y",220,"width",450,"height",100)) );
+        std::vector<std::string> labels;
+        labels.push_back("x"); labels.push_back("abs cos x"); labels.push_back("abs sin x"); labels.push_back("sin sin x");
+        VIBES_TEST( vibes::axisLabels(labels) );
+    }
 
     VIBES_TEST( vibes::newFigure("figureTest") );
 
@@ -182,7 +220,7 @@ int main()
         x.push_back(2);     y.push_back(7);
         x.push_back(0.5);   y.push_back(4);
         x.push_back(-0.5);  y.push_back(4);
-        VIBES_TEST( vibes::drawPolygon(x, y, "yellow[red]") );
+        VIBES_TEST( vibes::drawPolygon(x, y, "red--[yellowgreen]") );
     }
 
     cout << "drawVehicle" << std::endl;

--- a/client-api/C++/examples/all_commands.cpp
+++ b/client-api/C++/examples/all_commands.cpp
@@ -62,11 +62,12 @@ int main()
             boxes_bounds.push_back(box_bounds);
         }
         VIBES_TEST( vibes::newFigure("Megatest with boxes") );
-        VIBES_TEST( vibes::drawBoxes(boxes_bounds,"[darkYellow]") );
+        VIBES_TEST( vibes::drawBoxes(boxes_bounds,"darkYellow-.[128,128,0,40]") );
         VIBES_TEST( vibes::setFigureProperties(vibesParams("x",0,"y",40,"width",150,"height",150)) );
 
         VIBES_TEST( vibes::newFigure("Megatest with boxes union") );
-        VIBES_TEST( vibes::drawBoxesUnion(boxes_bounds,"[darkGreen]") );
+        VIBES_TEST(vibes::drawBox(5,15,5,15,"-khaki[black]"));
+        VIBES_TEST( vibes::drawBoxesUnion(boxes_bounds,"darkGreen:[0,128,128,100]") );
         VIBES_TEST( vibes::setFigureProperties(vibesParams("x",150,"y",40,"width",150,"height",150)) );
     }
 

--- a/client-api/C++/examples/all_commands.cpp
+++ b/client-api/C++/examples/all_commands.cpp
@@ -67,6 +67,11 @@ int main()
 
         VIBES_TEST( vibes::newFigure("Megatest with boxes union") );
         VIBES_TEST(vibes::drawBox(5,15,5,15,"-khaki[black]"));
+        VIBES_TEST(vibes::drawBox(0,10,0,10,"red-..[green]"));
+    VIBES_TEST(vibes::drawBox(10,20,10,20,vibesParams("FaceColor","red","EdgeColor",(vibes::RGBA){128,0,249,128})));
+    VIBES_TEST(vibes::drawBox(20,30,20,30,vibesParams("FaceColor",(vibes::RGBA){0,255,0,128},"EdgeColor","blue","LineStyle","-..","LineWidth",0.1)));
+    VIBES_TEST(vibes::drawBox(25,40,25,40,"255,255,255,129--[128,128,128,100]"));
+    
         VIBES_TEST( vibes::drawBoxesUnion(boxes_bounds,"darkGreen:[0,128,128,100]") );
         VIBES_TEST( vibes::setFigureProperties(vibesParams("x",150,"y",40,"width",150,"height",150)) );
     }
@@ -238,8 +243,8 @@ int main()
     VIBES_TEST( vibes::drawArrow(20., 20., 40., 40., 3., "black[yellow]") );
     VIBES_TEST( vibes::drawArrow(40., 50., 20., 30., 4., "black[yellow]") );
 
-    VIBES_TEST( vibes::drawArrow(20., 65., 40., 65., 2., "black[red]") );
-    VIBES_TEST( vibes::drawArrow(40., 62., 20., 62., 2., "black[red]") );
+    VIBES_TEST( vibes::drawArrow(20., 65., 40., 65., 2., "black:[indigo]") );
+    VIBES_TEST( vibes::drawArrow(40., 62., 20., 62., 2., "black--[0,0,0,100]") );
 
     VIBES_TEST( vibes::drawArrow(65., 70., 65., 50., 2., "black[red]") );
     VIBES_TEST( vibes::drawArrow(62., 50., 62., 70., 2., "black[red]") );
@@ -251,9 +256,9 @@ int main()
     VIBES_TEST( vibes::drawSector(0,0,3,3,20, 120, "black[red]") ); 
 
     cout << "drawPie" << std::endl;
-    VIBES_TEST( vibes::drawPie(0,-20,3,4,20, 120, "black[red]") );
-    VIBES_TEST( vibes::drawPie(0,-20,3,1,-20, -220, "black[red]") );
-    VIBES_TEST( vibes::drawPie(10,-20,3,4,700, 800, "black[red]") );
+    VIBES_TEST( vibes::drawPie(0,-20,3,4,20, 120, "springgreen:[teal]") );
+    VIBES_TEST( vibes::drawPie(0,-20,3,1,-20, -220, "black[slateblue]") );
+    VIBES_TEST( vibes::drawPie(10,-20,3,4,700, 800, "black:[red]") );
     VIBES_TEST( vibes::drawPie(5,-20,3,3,20, 120, "black[red]") ); 
 
     cout << "drawBoxes with vector of vector of bounds" << std::endl;

--- a/client-api/C++/examples/all_commands.cpp
+++ b/client-api/C++/examples/all_commands.cpp
@@ -209,7 +209,7 @@ int main()
 
     VIBES_TEST( vibesDrawEllipse(-1,-1,1.5,2,30.0, "parent",0.1, "g") );
 
-    VIBES_TEST( vibes::drawEllipse(0,-4.75,4,0.25,0.0, "darkGray") );
+    VIBES_TEST( vibes::drawEllipse(0,-4.75,4,0.25,0.0, "darkGray-..[255,10,10,128]") );
 
     cout << "drawPolygon with vector of bounds" << std::endl;
     {

--- a/viewer/vibesgraphicsitem.cpp
+++ b/viewer/vibesgraphicsitem.cpp
@@ -487,7 +487,7 @@ bool VibesGraphicsBoxes::computeProjection(int dimX, int dimY)
     const QJsonObject & json = this->_json;
 
     // Get shape color (or default if not specified)
-    QBrush brush = vibesDefaults.brush( jsonValue("FaceColor") );
+    const QBrush &brush = vibesDefaults.brush( jsonValue("FaceColor") );
     QPen pen = vibesDefaults.pen( jsonValue("EdgeColor") );
 
     // Now process shape-specific properties
@@ -605,10 +605,25 @@ bool VibesGraphicsBoxesUnion::parseJsonGraphics(const QJsonObject &json)
 
             // Compute dimension
             this->_nbDim = nbCols / 2;
-
+            
+            QPen pen = vibesDefaults.pen( jsonValue("EdgeColor"));
+            const QBrush &brush=vibesDefaults.brush( jsonValue("FaceColor"));
+        // Handle lineStyle
+        if(json.contains("LineStyle"))
+        {
+            Q_ASSERT(json["LineStyle"].isString());
+            string style=json["LineStyle"].toString().toStdString();
+            pen.setStyle(vibesDefaults.styleToPenStyle(style));
+        }
+        // Handle lineStyle
+        if(json.contains("LineWidth"))
+        {
+                    Q_ASSERT(json["LineWidth"].isDouble());
+            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+        }
             // Set graphical properties
-            this->setPen( vibesDefaults.pen( jsonValue("EdgeColor") ) );
-            this->setBrush( vibesDefaults.brush( jsonValue("FaceColor") ) );
+            this->setPen( pen );
+            this->setBrush( brush );
 
             // Update successful
             return true;
@@ -626,7 +641,7 @@ bool VibesGraphicsBoxesUnion::computeProjection(int dimX, int dimY)
 
     // Get shape color (or default if not specified)
     const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    QPen pen = vibesDefaults.pen( jsonValue("EdgeColor") );
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
@@ -654,6 +669,19 @@ bool VibesGraphicsBoxesUnion::computeProjection(int dimX, int dimY)
     }
     this->setPath(path);
     // Set graphics properties
+    // Handle lineStyle
+        if(json.contains("LineStyle"))
+        {
+            Q_ASSERT(json["LineStyle"].isString());
+            string style=json["LineStyle"].toString().toStdString();
+            pen.setStyle(vibesDefaults.styleToPenStyle(style));
+        }
+        // Handle lineStyle
+        if(json.contains("LineWidth"))
+        {
+                    Q_ASSERT(json["LineWidth"].isDouble());
+            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+        }
     this->setPen(pen);
     this->setBrush(brush);
 

--- a/viewer/vibesgraphicsitem.cpp
+++ b/viewer/vibesgraphicsitem.cpp
@@ -78,10 +78,8 @@ void VibesDefaults::initDefaultBrushesAndPens()
     ADD_DEFAULT_BRUSH_AND_PEN(darkBlue);
 }
 
-
-
 VibesGraphicsItem::VibesGraphicsItem(QGraphicsItem *qGraphicsItem)
- : _qGraphicsItem(qGraphicsItem), _nbDim(0), _dimX(-1), _dimY(-1)
+: _qGraphicsItem(qGraphicsItem), _nbDim(0), _dimX(-1), _dimY(-1)
 {
 }
 
@@ -101,25 +99,24 @@ QJsonValue VibesGraphicsItem::jsonValue(const QString& key) const
     {
         return json()[key];
     }
-    // Else, return the property from its parent group
+        // Else, return the property from its parent group
     else
     {
         const VibesGraphicsGroup* group = 0;
         if (_qGraphicsItem)
-             group = qgraphicsitem_cast<const VibesGraphicsGroup*>(_qGraphicsItem->parentItem());
+            group = qgraphicsitem_cast<const VibesGraphicsGroup*>(_qGraphicsItem->parentItem());
         // Item is member of a group, ask the group for the requested property
         if (group)
         {
             return group->jsonValue(key);
         }
-        // Item has no parent group, then return an empty value
+            // Item has no parent group, then return an empty value
         else
         {
             return QJsonValue();
         }
     }
 }
-
 
 void VibesGraphicsItem::setJsonValue(const QString &key, const QJsonValue &value)
 {
@@ -154,12 +151,11 @@ void VibesGraphicsItem::setJsonValues(const QJsonObject &values)
         computeProjection(_dimX, _dimY);
 }
 
-
 bool VibesGraphicsItem::setProj(int dimX, int dimY)
 {
     _dimX = dimX;
     _dimY = dimY;
-    if (existsInProj(_dimX,_dimY))
+    if (existsInProj(_dimX, _dimY))
     {
         return computeProjection(_dimX, _dimY);
     }
@@ -172,43 +168,56 @@ bool VibesGraphicsItem::setProj(int dimX, int dimY)
 
 VibesGraphicsItem * VibesGraphicsItem::newWithType(const QString type)
 {
-    if (type == "group") {
+    if (type == "group")
+    {
         return new VibesGraphicsGroup();
     }
-    else if (type == "box") {
+    else if (type == "box")
+    {
         return new VibesGraphicsBox();
     }
-    else if (type == "boxes") {
+    else if (type == "boxes")
+    {
         return new VibesGraphicsBoxes();
     }
-    else if (type == "boxes union") {
+    else if (type == "boxes union")
+    {
         return new VibesGraphicsBoxesUnion();
     }
-    else if (type == "ellipse") {
+    else if (type == "ellipse")
+    {
         return new VibesGraphicsEllipse();
     }
-    else if (type == "pie") {
+    else if (type == "pie")
+    {
         return new VibesGraphicsPie();
     }
-    else if (type == "point") {
+    else if (type == "point")
+    {
         //! \todo Implement "point" type
     }
-    else if (type == "points") {
+    else if (type == "points")
+    {
         //! \todo Implement "points" type
     }
-    else if (type == "line") {
+    else if (type == "line")
+    {
         return new VibesGraphicsLine();
     }
-    else if (type == "arrow") {
+    else if (type == "arrow")
+    {
         return new VibesGraphicsArrow();
     }
-    else if (type == "polygon") {
+    else if (type == "polygon")
+    {
         return new VibesGraphicsPolygon();
     }
-    else if (type == "vehicle") {
+    else if (type == "vehicle")
+    {
         return new VibesGraphicsVehicle();
     }
-    else if (type == "vehicle_auv") {
+    else if (type == "vehicle_auv")
+    {
         return new VibesGraphicsVehicleAUV();
     }
     return 0;
@@ -226,16 +235,18 @@ bool VibesGraphicsItem::parseJson(QJsonObject &json)
         int fcEnd = format.lastIndexOf(']');
         if (fcStart < fcEnd)
         {
-            json["FaceColor"] = QJsonValue(format.mid(fcStart+1, fcEnd-fcStart-1).trimmed());
-            format.remove(fcStart, fcEnd-fcStart+1);
+            json["FaceColor"] = QJsonValue(format.mid(fcStart + 1, fcEnd - fcStart - 1).trimmed());
+            format.remove(fcStart, fcEnd - fcStart + 1);
         }
         // Extract LineStyle
         // ! styles with redundant parts must have their longest version
         // placed at the end of the array
-        const QStringList lineStyles = {"-","--","-.","-..",":"};
+        const QStringList lineStyles = {"-", "--", "-.", "-..", ":"};
         QStringList presentStyles;
         vector<int> fcStarts;
-        foreach (const QString ls, lineStyles) {
+
+        foreach(const QString ls, lineStyles)
+        {
             fcStart = format.indexOf(ls);
             if (fcStart >= 0)
             {
@@ -243,10 +254,10 @@ bool VibesGraphicsItem::parseJson(QJsonObject &json)
                 fcStarts.push_back(fcStart);
             }
         }
-        if(presentStyles.size()>0)
+        if (presentStyles.size() > 0)
         {
-            json["LineStyle"]=QJsonValue(presentStyles.back());
-            format.remove(fcStarts.back(),presentStyles.back().size());
+            json["LineStyle"] = QJsonValue(presentStyles.back());
+            format.remove(fcStarts.back(), presentStyles.back().size());
         }
         // Extract EdgeColor
         format = format.trimmed();
@@ -268,10 +279,10 @@ bool VibesGraphicsItem::parseJson(QJsonObject &json)
     return parseJsonGraphics(json);
 }
 
-
 bool VibesGraphicsItem::isJsonMatrix(const QJsonValue value, int &nbRows, int &nbCols)
 {
-    nbRows = 0; nbCols = 0;
+    nbRows = 0;
+    nbCols = 0;
     // Check number of rows
     if (!value.isArray()) return false;
     QJsonArray lines = value.toArray();
@@ -301,7 +312,7 @@ void VibesGraphicsGroup::addToGroup(VibesGraphicsItem *item)
     // Update item with group properties
     if (VibesGraphicsItem::scene())
     {
-        item->setProj(VibesGraphicsItem::scene()->dimX(),VibesGraphicsItem::scene()->dimY());
+        item->setProj(VibesGraphicsItem::scene()->dimX(), VibesGraphicsItem::scene()->dimY());
     }
 }
 
@@ -309,6 +320,7 @@ void VibesGraphicsGroup::clear()
 {
     // Remove all children
     QList<QGraphicsItem*> children = this->childItems();
+
     foreach(QGraphicsItem* child, children)
     {
         VibesGraphicsItem * item = qgraphicsitem_cast<VibesGraphicsItem *>(child);
@@ -320,6 +332,7 @@ bool VibesGraphicsGroup::parseJsonGraphics(const QJsonObject &json)
 {
     // Set graphical properties
     QList<QGraphicsItem*> children = this->childItems();
+
     foreach(QGraphicsItem* child, children)
     {
         VibesGraphicsItem * item = qgraphicsitem_cast<VibesGraphicsItem *>(child);
@@ -344,7 +357,7 @@ bool VibesGraphicsBox::parseJsonGraphics(const QJsonObject &json)
             QJsonDocument doc(json);
             QJsonArray bounds = json["bounds"].toArray();
             // We need at least a 2-D box. Number of bounds has to be even.
-            if (bounds.size() < 4 || bounds.size()%2 != 0)
+            if (bounds.size() < 4 || bounds.size() % 2 != 0)
                 return false;
 
             // Compute dimension
@@ -352,8 +365,8 @@ bool VibesGraphicsBox::parseJsonGraphics(const QJsonObject &json)
 
             // Set graphical properties
             // Those seems to be called on NULL values
-            this->setPen( vibesDefaults.pen( jsonValue("EdgeColor") ) );
-            this->setBrush( vibesDefaults.brush( jsonValue("FaceColor") ) );
+            this->setPen(vibesDefaults.pen(jsonValue("EdgeColor")));
+            this->setBrush(vibesDefaults.brush(jsonValue("FaceColor")));
 
             // Update successful
             return true;
@@ -367,10 +380,10 @@ bool VibesGraphicsBox::parseJsonGraphics(const QJsonObject &json)
 bool VibesGraphicsBox::computeProjection(int dimX, int dimY)
 {
     const QJsonObject & json = this->_json;
-    
+
     // Get shape color (or default if not specified)
-    QBrush brush = vibesDefaults.brush( jsonValue("FaceColor"));
-    QPen pen = vibesDefaults.pen( jsonValue("EdgeColor"));
+    QBrush brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     Q_ASSERT(json.contains("type"));
     Q_ASSERT(json["type"].toString() == "box");
@@ -378,35 +391,35 @@ bool VibesGraphicsBox::computeProjection(int dimX, int dimY)
     QJsonArray bounds = json["bounds"].toArray();
     // Compute dimension
     Q_ASSERT(this->_nbDim == bounds.size() / 2);
-    Q_ASSERT(bounds.size() >= (2*(qMax(dimX,dimY)+1)));
+    Q_ASSERT(bounds.size() >= (2 * (qMax(dimX, dimY) + 1)));
 
     // Read bounds
-    double lb_x = bounds[2*dimX].toDouble();
-    double ub_x = bounds[2*dimX+1].toDouble();
-    double lb_y = bounds[2*dimY].toDouble();
-    double ub_y = bounds[2*dimY+1].toDouble();
+    double lb_x = bounds[2 * dimX].toDouble();
+    double ub_x = bounds[2 * dimX + 1].toDouble();
+    double lb_y = bounds[2 * dimY].toDouble();
+    double ub_y = bounds[2 * dimY + 1].toDouble();
 
     // Update rectangle
     this->setRect(lb_x, lb_y, ub_x - lb_x, ub_y - lb_y);
 
     // Handle lineStyle
-    if(json.contains("LineStyle"))
+    if (json.contains("LineStyle"))
     {
         Q_ASSERT(json["LineStyle"].isString());
-        string style=json["LineStyle"].toString().toStdString();
+        string style = json["LineStyle"].toString().toStdString();
         pen.setStyle(vibesDefaults.styleToPenStyle(style));
     }
     // Handle lineStyle
-    if(json.contains("LineWidth"))
+    if (json.contains("LineWidth"))
     {
         Q_ASSERT(json["LineWidth"].isDouble());
-        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
     }
 
     // Update rectangle color
     this->setPen(pen);
     this->setBrush(brush);
-    
+
     // Update successful
     return true;
 }
@@ -432,45 +445,46 @@ bool VibesGraphicsBoxes::parseJsonGraphics(const QJsonObject &json)
             if (!isJsonMatrix(json["bounds"], nbRows, nbCols))
                 return false;
             // Number of bounds has to be even
-            if (nbCols%2 != 0)
+            if (nbCols % 2 != 0)
                 return false;
             // Number of bounds has to be at least 4 (to draw boxes)
             if (nbCols < 4)
                 return 0;
 
-//            bool colors = json.contains("colors");
-//            bool enoughColors = false;
-//            if (colors)
-//                enoughColors = json["colors"].toArray().size() == nbRows;
+            //            bool colors = json.contains("colors");
+            //            bool enoughColors = false;
+            //            if (colors)
+            //                enoughColors = json["colors"].toArray().size() == nbRows;
 
             // Compute dimension
             this->_nbDim = nbCols / 2;
 
             // Set graphical properties
             QList<QGraphicsItem*> rects = this->childItems();
+
             foreach(QGraphicsItem* item, rects)
             {
                 QGraphicsRectItem * rect = qgraphicsitem_cast<QGraphicsRectItem *>(item);
                 if (!rect) continue;
-                
-                QPen pen=vibesDefaults.pen( jsonValue("EdgeColor") ) ;
-                QBrush brush=vibesDefaults.brush( jsonValue("EdgeColor") ) ;
+
+                QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
+                QBrush brush = vibesDefaults.brush(jsonValue("EdgeColor"));
                 // Handle lineStyle
-                if(json.contains("LineStyle"))
+                if (json.contains("LineStyle"))
                 {
                     Q_ASSERT(json["LineStyle"].isString());
-                    string style=json["LineStyle"].toString().toStdString();
+                    string style = json["LineStyle"].toString().toStdString();
                     pen.setStyle(vibesDefaults.styleToPenStyle(style));
                 }
                 // Handle lineStyle
-                if(json.contains("LineWidth"))
+                if (json.contains("LineWidth"))
                 {
                     Q_ASSERT(json["LineWidth"].isDouble());
-                    pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+                    pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
                 }
-                
-                rect->setPen( pen);
-                rect->setBrush( brush );
+
+                rect->setPen(pen);
+                rect->setBrush(brush);
             }
 
             // Update successful
@@ -487,14 +501,14 @@ bool VibesGraphicsBoxes::computeProjection(int dimX, int dimY)
     const QJsonObject & json = this->_json;
 
     // Get shape color (or default if not specified)
-    const QBrush &brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    QPen pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    const QBrush &brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
-    Q_ASSERT (json.contains("type"));
+    Q_ASSERT(json.contains("type"));
     // VibesGraphicsBoxes has JSON type "boxes"
-    Q_ASSERT ( json["type"].toString() == "boxes" );
+    Q_ASSERT(json["type"].toString() == "boxes");
 
     // VibesGraphicsBoxes is basically a QGraphicsItemGroup containing QGraphicsRectItems
     // Before update, we first remove all existing rectangles
@@ -503,68 +517,70 @@ bool VibesGraphicsBoxes::computeProjection(int dimX, int dimY)
         foreach(QGraphicsItem* rect, rects) delete rect;
     }
     // "bounds" is a matrix
-    Q_ASSERT ( isJsonMatrix(json["bounds"]) );
+    Q_ASSERT(isJsonMatrix(json["bounds"]));
 
     // Fill group with projected boxes
-    foreach (const QJsonValue value, json["bounds"].toArray()) {
+
+    foreach(const QJsonValue value, json["bounds"].toArray())
+    {
         const QJsonArray box = value.toArray();
         // Read bounds
-        double lb_x = box[2*dimX].toDouble();
-        double ub_x = box[2*dimX+1].toDouble();
-        double lb_y = box[2*dimY].toDouble();
-        double ub_y = box[2*dimY+1].toDouble();
+        double lb_x = box[2 * dimX].toDouble();
+        double ub_x = box[2 * dimX + 1].toDouble();
+        double lb_y = box[2 * dimY].toDouble();
+        double ub_y = box[2 * dimY + 1].toDouble();
         // Create a new rect
         QGraphicsRectItem * rect = new QGraphicsRectItem(lb_x, lb_y, ub_x - lb_x, ub_y - lb_y);
-        
+
         // Handle lineStyle
-        if(json.contains("LineStyle"))
+        if (json.contains("LineStyle"))
         {
             Q_ASSERT(json["LineStyle"].isString());
-            string style=json["LineStyle"].toString().toStdString();
+            string style = json["LineStyle"].toString().toStdString();
             pen.setStyle(vibesDefaults.styleToPenStyle(style));
         }
         // Handle lineStyle
-        if(json.contains("LineWidth"))
+        if (json.contains("LineWidth"))
         {
-                    Q_ASSERT(json["LineWidth"].isDouble());
-            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+            Q_ASSERT(json["LineWidth"].isDouble());
+            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
         }
-        
+
         rect->setPen(pen);
         rect->setBrush(brush);
         // Add it to the group
-        this->addToGroup( rect );
+        this->addToGroup(rect);
     }
 
-/*
-    QJsonArray boundsX_lb = json["boundsX_lb"].toArray();
-    QJsonArray boundsX_ub = json["boundsX_ub"].toArray();
-    QJsonArray boundsY_lb = json["boundsY_lb"].toArray();
-    QJsonArray boundsY_ub = json["boundsY_ub"].toArray();
+    /*
+        QJsonArray boundsX_lb = json["boundsX_lb"].toArray();
+        QJsonArray boundsX_ub = json["boundsX_ub"].toArray();
+        QJsonArray boundsY_lb = json["boundsY_lb"].toArray();
+        QJsonArray boundsY_ub = json["boundsY_ub"].toArray();
 
-    if (boundsX_lb.size() == boundsX_ub.size() &&
-            boundsX_ub.size() == boundsY_lb.size() &&
-            boundsY_lb.size() == boundsY_ub.size())
-    {
-        bool colors = json.contains("colors");
-        bool enoughColors = false;
-        if (colors)
-            enoughColors = json["colors"].toArray().size() == boundsX_lb.size();
-        for (int i = 0; i < boundsX_lb.size(); i++)
+        if (boundsX_lb.size() == boundsX_ub.size() &&
+                boundsX_ub.size() == boundsY_lb.size() &&
+                boundsY_lb.size() == boundsY_ub.size())
         {
-            // Read bounds
-            double lb_x = boundsX_lb[i].toDouble();
-            double ub_x = boundsX_ub[i].toDouble();
-            double lb_y = boundsY_lb[i].toDouble();
-            double ub_y = boundsY_ub[i].toDouble();
-            // Create a new rect
-            QGraphicsRectItem * rect = new QGraphicsRectItem(lb_x, lb_y, ub_x - lb_x, ub_y - lb_y);
-            rect->setPen(pen);
-            rect->setBrush(brush);
-            // Add it to the group
-            this->addToGroup( rect );
-        }
-*/
+            bool colors = json.contains("colors");
+            bool enoughColors = false;
+            if (colors)
+                enoughColors = json["colors"].toArray().size() == boundsX_lb.size();
+            for (int i = 0; i < boundsX_lb.size(); i++)
+            {
+                // Read bounds
+                double lb_x = boundsX_lb[i].toDouble();
+                double ub_x = boundsX_ub[i].toDouble();
+                double lb_y = boundsY_lb[i].toDouble();
+                double ub_y = boundsY_ub[i].toDouble();
+                // Create a new rect
+                QGraphicsRectItem * rect = new QGraphicsRectItem(lb_x, lb_y, ub_x - lb_x, ub_y - lb_y);
+                rect->setPen(pen);
+                rect->setBrush(brush);
+                // Add it to the group
+                this->addToGroup( rect );
+            }
+     */
 
     // Update successful
     return true;
@@ -592,38 +608,38 @@ bool VibesGraphicsBoxesUnion::parseJsonGraphics(const QJsonObject &json)
             if (!isJsonMatrix(json["bounds"], nbRows, nbCols))
                 return false;
             // Number of bounds has to be even
-            if (nbCols%2 != 0)
+            if (nbCols % 2 != 0)
                 return false;
             // Number of bounds has to be at least 4 (to draw boxes)
             if (nbCols < 4)
                 return 0;
 
-//            bool colors = json.contains("colors");
-//            bool enoughColors = false;
-//            if (colors)
-//                enoughColors = json["colors"].toArray().size() == nbRows;
+            //            bool colors = json.contains("colors");
+            //            bool enoughColors = false;
+            //            if (colors)
+            //                enoughColors = json["colors"].toArray().size() == nbRows;
 
             // Compute dimension
             this->_nbDim = nbCols / 2;
-            
-            QPen pen = vibesDefaults.pen( jsonValue("EdgeColor"));
-            const QBrush &brush=vibesDefaults.brush( jsonValue("FaceColor"));
-        // Handle lineStyle
-        if(json.contains("LineStyle"))
-        {
-            Q_ASSERT(json["LineStyle"].isString());
-            string style=json["LineStyle"].toString().toStdString();
-            pen.setStyle(vibesDefaults.styleToPenStyle(style));
-        }
-        // Handle lineStyle
-        if(json.contains("LineWidth"))
-        {
-                    Q_ASSERT(json["LineWidth"].isDouble());
-            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
-        }
+
+            QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
+            const QBrush &brush = vibesDefaults.brush(jsonValue("FaceColor"));
+            // Handle lineStyle
+            if (json.contains("LineStyle"))
+            {
+                Q_ASSERT(json["LineStyle"].isString());
+                string style = json["LineStyle"].toString().toStdString();
+                pen.setStyle(vibesDefaults.styleToPenStyle(style));
+            }
+            // Handle lineStyle
+            if (json.contains("LineWidth"))
+            {
+                Q_ASSERT(json["LineWidth"].isDouble());
+                pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
+            }
             // Set graphical properties
-            this->setPen( pen );
-            this->setBrush( brush );
+            this->setPen(pen);
+            this->setBrush(brush);
 
             // Update successful
             return true;
@@ -634,33 +650,34 @@ bool VibesGraphicsBoxesUnion::parseJsonGraphics(const QJsonObject &json)
     return false;
 }
 
-
 bool VibesGraphicsBoxesUnion::computeProjection(int dimX, int dimY)
 {
     const QJsonObject & json = this->_json;
 
     // Get shape color (or default if not specified)
-    const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    QPen pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    const QBrush & brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
-    Q_ASSERT (json.contains("type"));
+    Q_ASSERT(json.contains("type"));
     // VibesGraphicsBoxes has JSON type "boxes union"
-    Q_ASSERT ( json["type"].toString() == "boxes union" );
+    Q_ASSERT(json["type"].toString() == "boxes union");
     // "bounds" is a matrix
-    Q_ASSERT ( isJsonMatrix(json["bounds"]) );
+    Q_ASSERT(isJsonMatrix(json["bounds"]));
 
     // Update path with projected boxes
     QPainterPath path;
     path.setFillRule(Qt::WindingFill);
-    foreach (const QJsonValue value, json["bounds"].toArray()) {
+
+    foreach(const QJsonValue value, json["bounds"].toArray())
+    {
         const QJsonArray box = value.toArray();
         // Read bounds
-        double lb_x = box[2*dimX].toDouble();
-        double ub_x = box[2*dimX+1].toDouble();
-        double lb_y = box[2*dimY].toDouble();
-        double ub_y = box[2*dimY+1].toDouble();
+        double lb_x = box[2 * dimX].toDouble();
+        double ub_x = box[2 * dimX + 1].toDouble();
+        double lb_y = box[2 * dimY].toDouble();
+        double ub_y = box[2 * dimY + 1].toDouble();
         // Create a new rect path
         QPainterPath rect_path;
         rect_path.addRect(lb_x, lb_y, ub_x - lb_x, ub_y - lb_y);
@@ -670,18 +687,18 @@ bool VibesGraphicsBoxesUnion::computeProjection(int dimX, int dimY)
     this->setPath(path);
     // Set graphics properties
     // Handle lineStyle
-        if(json.contains("LineStyle"))
-        {
-            Q_ASSERT(json["LineStyle"].isString());
-            string style=json["LineStyle"].toString().toStdString();
-            pen.setStyle(vibesDefaults.styleToPenStyle(style));
-        }
-        // Handle lineStyle
-        if(json.contains("LineWidth"))
-        {
-                    Q_ASSERT(json["LineWidth"].isDouble());
-            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
-        }
+    if (json.contains("LineStyle"))
+    {
+        Q_ASSERT(json["LineStyle"].isString());
+        string style = json["LineStyle"].toString().toStdString();
+        pen.setStyle(vibesDefaults.styleToPenStyle(style));
+    }
+    // Handle lineStyle
+    if (json.contains("LineWidth"))
+    {
+        Q_ASSERT(json["LineWidth"].isDouble());
+        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
+    }
     this->setPen(pen);
     this->setBrush(brush);
 
@@ -715,7 +732,8 @@ bool VibesGraphicsEllipse::parseJsonGraphics(const QJsonObject &json)
                     if (center.size() != 2) return false;
                     if (json["axis"].toArray().size() != 2) return false;
 
-                } else if (json.contains("angles"))
+                }
+                else if (json.contains("angles"))
                 {
                     if (json["angles"].toArray().size() != 2) return false;
                 }
@@ -724,7 +742,7 @@ bool VibesGraphicsEllipse::parseJsonGraphics(const QJsonObject &json)
                     // A covariance matrix has been provided (Confidence ellipse)
                     double k = json.contains("sigma") ? json["sigma"].toDouble() : 5;
                     QJsonArray covariance = json["covariance"].toArray();
-                    if (covariance.size() != pow(center.size(),2)) return false;
+                    if (covariance.size() != pow(center.size(), 2)) return false;
                 }
                 else
                 {
@@ -735,8 +753,8 @@ bool VibesGraphicsEllipse::parseJsonGraphics(const QJsonObject &json)
                 this->_nbDim = center.size();
 
                 // Set graphical properties
-                this->setPen( vibesDefaults.pen( jsonValue("EdgeColor") ) );
-                this->setBrush( vibesDefaults.brush( jsonValue("FaceColor") ) );
+                this->setPen(vibesDefaults.pen(jsonValue("EdgeColor")));
+                this->setBrush(vibesDefaults.brush(jsonValue("FaceColor")));
 
                 // Update successful
                 return true;
@@ -753,17 +771,17 @@ bool VibesGraphicsEllipse::computeProjection(int dimX, int dimY)
     const QJsonObject & json = this->_json;
 
     // Get shape color (or default if not specified)
-    const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    const QBrush & brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
-    Q_ASSERT (json.contains("type"));
+    Q_ASSERT(json.contains("type"));
     Q_ASSERT(json["type"].toString() == "ellipse");
 
     QJsonArray center = json["center"].toArray();
 
-    Q_ASSERT (center.size() >= 2);
+    Q_ASSERT(center.size() >= 2);
     Q_ASSERT(this->_nbDim == center.size());
-    Q_ASSERT(center.size() >= (qMax(dimX,dimY)+1));
+    Q_ASSERT(center.size() >= (qMax(dimX, dimY) + 1));
 
     // Get center
     double x = center[dimX].toDouble();
@@ -779,14 +797,14 @@ bool VibesGraphicsEllipse::computeProjection(int dimX, int dimY)
     if (json.contains("axis") && json.contains("orientation"))
     {
         // Semi-major and semi-minor axes are directly provided (Ellipse or circle)
-        Q_ASSERT ((dimX==0 && dimY==1) || (dimX==1 && dimY==0));
+        Q_ASSERT((dimX == 0 && dimY == 1) || (dimX == 1 && dimY == 0));
 
         QJsonArray axis = json["axis"].toArray();
         wx = axis[0].toDouble();
         wy = axis[1].toDouble();
-        if (dimX==0 && dimY==1)
+        if (dimX == 0 && dimY == 1)
             angle = json.value("orientation").toDouble();
-        else if (dimX==1 && dimY==0)
+        else if (dimX == 1 && dimY == 0)
             angle = 90.0 - json.value("orientation").toDouble();
         else
             return false;
@@ -796,12 +814,12 @@ bool VibesGraphicsEllipse::computeProjection(int dimX, int dimY)
         // A covariance matrix has been provided (Confidence ellipse)
         double k = json.contains("sigma") ? json["sigma"].toDouble() : 5;
         QJsonArray covariance = json["covariance"].toArray();
-        Q_ASSERT (covariance.size() == center.size()*center.size());
-        double sxx = covariance[dimX + center.size()*dimX].toDouble();
-        double sxy = covariance[dimX + center.size()*dimY].toDouble();
-        double syy = covariance[dimY + center.size()*dimY].toDouble();
+        Q_ASSERT(covariance.size() == center.size() * center.size());
+        double sxx = covariance[dimX + center.size() * dimX].toDouble();
+        double sxy = covariance[dimX + center.size() * dimY].toDouble();
+        double syy = covariance[dimY + center.size() * dimY].toDouble();
         // Compute the semi-major and semi-minor axes and rotation angle.
-        axisAngleFromCovarianceK(sxx,syy,sxy,k, wx,wy,angle);
+        axisAngleFromCovarianceK(sxx, syy, sxy, k, wx, wy, angle);
     }
     else
     {
@@ -812,16 +830,29 @@ bool VibesGraphicsEllipse::computeProjection(int dimX, int dimY)
     if (json.contains("angles"))
     {
         QJsonArray bounds = json["angles"].toArray();
-        angle_min = static_cast<int>( bounds[0].toDouble()*16);
-        angle_max = static_cast<int>( bounds[1].toDouble()*16);
+        angle_min = static_cast<int> (bounds[0].toDouble()*16);
+        angle_max = static_cast<int> (bounds[1].toDouble()*16);
     }
     // Update ellipse
     this->setRect(-wx, -wy, 2 * wx, 2 * wy);
     this->setRotation(angle);
     this->setPos(x, y);
     this->setStartAngle(angle_min);
-    this->setSpanAngle( angle_max - angle_min );
+    this->setSpanAngle(angle_max - angle_min);
     // Update ellipse properties
+    // Handle lineStyle
+    if (json.contains("LineStyle"))
+    {
+        Q_ASSERT(json["LineStyle"].isString());
+        string style = json["LineStyle"].toString().toStdString();
+        pen.setStyle(vibesDefaults.styleToPenStyle(style));
+    }
+    // Handle lineStyle
+    if (json.contains("LineWidth"))
+    {
+        Q_ASSERT(json["LineWidth"].isDouble());
+        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
+    }
     this->setPen(pen);
     this->setBrush(brush);
     // Update successful
@@ -894,7 +925,7 @@ bool VibesGraphicsLine::parseJsonGraphics(const QJsonObject &json)
             this->_nbDim = nbCols;
 
             // Set pen
-            this->setPen( vibesDefaults.pen( jsonValue("EdgeColor") ) );
+            this->setPen(vibesDefaults.pen(jsonValue("EdgeColor")));
 
             // Update successful
             return true;
@@ -905,27 +936,28 @@ bool VibesGraphicsLine::parseJsonGraphics(const QJsonObject &json)
     return false;
 }
 
-
 bool VibesGraphicsLine::computeProjection(int dimX, int dimY)
 {
     const QJsonObject & json = this->_json;
 
     // Get line color (or default if not specified)
     //const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor").toString() );
-    QPen pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
-    Q_ASSERT (json.contains("type"));
+    Q_ASSERT(json.contains("type"));
     // VibesGraphicsLine has JSON type "line"
-    Q_ASSERT ( json["type"].toString() == "line" );
+    Q_ASSERT(json["type"].toString() == "line");
     // "bounds" is a matrix
-    Q_ASSERT ( isJsonMatrix(json["points"]) );
+    Q_ASSERT(isJsonMatrix(json["points"]));
 
     // Update line with projected points
     QPainterPath path;
     QPolygonF polygon;
-    foreach (const QJsonValue value, json["points"].toArray()) {
+
+    foreach(const QJsonValue value, json["points"].toArray())
+    {
         // Read coordinates and append them to the list of points
         const QJsonArray coords = value.toArray();
         polygon << QPointF(coords[dimX].toDouble(), coords[dimY].toDouble());
@@ -935,17 +967,17 @@ bool VibesGraphicsLine::computeProjection(int dimX, int dimY)
     this->setPath(path);
     // Set graphics properties
     // Handle lineStyle
-    if(json.contains("LineStyle"))
+    if (json.contains("LineStyle"))
     {
         Q_ASSERT(json["LineStyle"].isString());
-        string style=json["LineStyle"].toString().toStdString();
+        string style = json["LineStyle"].toString().toStdString();
         pen.setStyle(vibesDefaults.styleToPenStyle(style));
     }
     // Handle lineStyle
-    if(json.contains("LineWidth"))
+    if (json.contains("LineWidth"))
     {
         Q_ASSERT(json["LineWidth"].isDouble());
-        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
     }
     this->setPen(pen);
     //this->setBrush(brush);
@@ -978,8 +1010,8 @@ bool VibesGraphicsPolygon::parseJsonGraphics(const QJsonObject &json)
             this->_nbDim = nbCols;
 
             // Set pen
-            this->setPen( vibesDefaults.pen( jsonValue("EdgeColor") ) );
-            this->setBrush( vibesDefaults.brush( jsonValue("FaceColor") ) );
+            this->setPen(vibesDefaults.pen(jsonValue("EdgeColor")));
+            this->setBrush(vibesDefaults.brush(jsonValue("FaceColor")));
 
             // Update successful
             return true;
@@ -995,15 +1027,17 @@ bool VibesGraphicsPolygon::computeProjection(int dimX, int dimY)
     const QJsonObject & json = this->_json;
 
     // Get shape color (or default if not specified)
-    QBrush brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    QPen pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    QBrush brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     Q_ASSERT(json.contains("type"));
     Q_ASSERT(json["type"].toString() == "polygon");
 
     // Update polygon
     QPolygonF polygon;
-    foreach (const QJsonValue value, json["bounds"].toArray()) {
+
+    foreach(const QJsonValue value, json["bounds"].toArray())
+    {
         // Read coordinates and append them to the list of points
         const QJsonArray coords = value.toArray();
         polygon << QPointF(coords[dimX].toDouble(), coords[dimY].toDouble());
@@ -1011,20 +1045,20 @@ bool VibesGraphicsPolygon::computeProjection(int dimX, int dimY)
     this->setPolygon(polygon);
 
     // Update polygon color
-    
+
     // Set graphics properties
     // Handle lineStyle
-    if(json.contains("LineStyle"))
+    if (json.contains("LineStyle"))
     {
         Q_ASSERT(json["LineStyle"].isString());
-        string style=json["LineStyle"].toString().toStdString();
+        string style = json["LineStyle"].toString().toStdString();
         pen.setStyle(vibesDefaults.styleToPenStyle(style));
     }
     // Handle lineStyle
-    if(json.contains("LineWidth"))
+    if (json.contains("LineWidth"))
     {
         Q_ASSERT(json["LineWidth"].isDouble());
-        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
     }
     this->setPen(pen);
     this->setBrush(brush);
@@ -1042,18 +1076,18 @@ bool VibesGraphicsVehicle::parseJsonGraphics(const QJsonObject &json)
 {
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
-    if(json.contains("type"))
+    if (json.contains("type"))
     {
         // Retrieve type
         QString type = json["type"].toString();
 
         // JSON type for VibesGraphicsVehicle is "vehicle"
-        if(type == "vehicle")
+        if (type == "vehicle")
         {
-            if(json.contains("center") && json.contains("length") && json.contains("orientation"))
+            if (json.contains("center") && json.contains("length") && json.contains("orientation"))
             {
                 int center_size = json["center"].toArray().size();
-                if(center_size == 2 && json["length"].toDouble() > 0.)
+                if (center_size == 2 && json["length"].toDouble() > 0.)
                 {
                     // Set dimension
                     this->_nbDim = center_size;
@@ -1074,8 +1108,8 @@ bool VibesGraphicsVehicle::computeProjection(int dimX, int dimY)
     const QJsonObject & json = this->_json;
 
     // Get shape color (or default if not specified)
-    const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    const QBrush & brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    const QPen & pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     Q_ASSERT(json.contains("type"));
     Q_ASSERT(json["type"].toString() == "vehicle");
@@ -1093,9 +1127,9 @@ bool VibesGraphicsVehicle::computeProjection(int dimX, int dimY)
 
     // Set polygon shape
     QPolygonF polygon;
-    polygon << QPointF(- 1. * length, 1. * length) + centerPoint;
-    polygon << QPointF(+ 3. * length, 0. * length) + centerPoint;
-    polygon << QPointF(- 1. * length, -1. * length) + centerPoint;
+    polygon << QPointF(-1. * length, 1. * length) + centerPoint;
+    polygon << QPointF(+3. * length, 0. * length) + centerPoint;
+    polygon << QPointF(-1. * length, -1. * length) + centerPoint;
 
     QGraphicsPolygonItem *graphics_polygon = new QGraphicsPolygonItem(polygon);
     graphics_polygon->setPen(pen);
@@ -1118,18 +1152,18 @@ bool VibesGraphicsVehicleAUV::parseJsonGraphics(const QJsonObject &json)
 {
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
-    if(json.contains("type"))
+    if (json.contains("type"))
     {
         // Retrieve type
         QString type = json["type"].toString();
 
         // JSON type for VibesGraphicsVehicleAUV is "vehicle_auv"
-        if(type == "vehicle_auv")
+        if (type == "vehicle_auv")
         {
-            if(json.contains("center") && json.contains("length") && json.contains("orientation"))
+            if (json.contains("center") && json.contains("length") && json.contains("orientation"))
             {
                 int center_size = json["center"].toArray().size();
-                if(center_size == 2 && json["length"].toDouble() > 0.)
+                if (center_size == 2 && json["length"].toDouble() > 0.)
                 {
                     // Set dimension
                     this->_nbDim = center_size;
@@ -1150,10 +1184,10 @@ bool VibesGraphicsVehicleAUV::computeProjection(int dimX, int dimY)
     const QJsonObject & json = this->_json;
 
     // Get shape color (or default if not specified)
-    const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    const QBrush & brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    const QPen & pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
-    Q_ASSERT (json.contains("type"));
+    Q_ASSERT(json.contains("type"));
     Q_ASSERT(json["type"].toString() == "vehicle_auv");
 
     QJsonArray center = json["center"].toArray();
@@ -1172,15 +1206,15 @@ bool VibesGraphicsVehicleAUV::computeProjection(int dimX, int dimY)
     // Set body shape
     {
         QPolygonF body;
-        body << QPointF(-4. * length,  0. * length) + centerPoint;
-        body << QPointF(-2. * length,  1. * length) + centerPoint;
-        body << QPointF( 2. * length,  1. * length) + centerPoint;
+        body << QPointF(-4. * length, 0. * length) + centerPoint;
+        body << QPointF(-2. * length, 1. * length) + centerPoint;
+        body << QPointF(2. * length, 1. * length) + centerPoint;
 
-        for(float i = 90. ; i > -90. ; i-=10.) // noise
-            body << QPointF( (cos(i  * M_PI / 180.0) + 2.) * length, 
-                             (sin(i  * M_PI / 180.0) + 0.) * length) + centerPoint;
+        for (float i = 90.; i > -90.; i -= 10.) // noise
+            body << QPointF((cos(i * M_PI / 180.0) + 2.) * length,
+                            (sin(i * M_PI / 180.0) + 0.) * length) + centerPoint;
 
-        body << QPointF( 2. * length, -1. * length) + centerPoint;
+        body << QPointF(2. * length, -1. * length) + centerPoint;
         body << QPointF(-2. * length, -1. * length) + centerPoint;
 
         QGraphicsPolygonItem *graphics_body = new QGraphicsPolygonItem(body);
@@ -1195,10 +1229,10 @@ bool VibesGraphicsVehicleAUV::computeProjection(int dimX, int dimY)
     // Set propulsion unit shape
     {
         QPolygonF propunit;
-        propunit << QPointF(- 4.  * length,  1 * length) + centerPoint;
-        propunit << QPointF(-3.25 * length,  1 * length) + centerPoint;
+        propunit << QPointF(-4. * length, 1 * length) + centerPoint;
+        propunit << QPointF(-3.25 * length, 1 * length) + centerPoint;
         propunit << QPointF(-3.25 * length, -1 * length) + centerPoint;
-        propunit << QPointF(- 4.  * length, -1 * length) + centerPoint;
+        propunit << QPointF(-4. * length, -1 * length) + centerPoint;
 
         QGraphicsPolygonItem *graphics_propunit = new QGraphicsPolygonItem(propunit);
         graphics_propunit->setPen(pen);
@@ -1252,24 +1286,23 @@ bool VibesGraphicsArrow::parseJsonGraphics(const QJsonObject &json)
     return false;
 }
 
-
 bool VibesGraphicsArrow::computeProjection(int dimX, int dimY)
 {
     const QJsonObject & json = this->_json;
 
     // Get arrow color (or default if not specified)
-    const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    const QBrush & brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    const QPen & pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
-    Q_ASSERT (json.contains("type"));
+    Q_ASSERT(json.contains("type"));
     // VibesGraphicsArrow has JSON type "arrow"
-    Q_ASSERT ( json["type"].toString() == "arrow" );
+    Q_ASSERT(json["type"].toString() == "arrow");
     // "bounds" is a matrix
-    Q_ASSERT ( isJsonMatrix(json["points"]) );
-    Q_ASSERT ( json["tip_length"].toDouble() > 0);
-    
+    Q_ASSERT(isJsonMatrix(json["points"]));
+    Q_ASSERT(json["tip_length"].toDouble() > 0);
+
     double before_last_x = 0., before_last_y = 0., last_x = 0., last_y = 0.;
 
     // Body
@@ -1277,7 +1310,9 @@ bool VibesGraphicsArrow::computeProjection(int dimX, int dimY)
         QPolygonF line;
 
         // Update line with projected points
-        foreach (const QJsonValue value, json["points"].toArray()) {
+
+        foreach(const QJsonValue value, json["points"].toArray())
+        {
             // Read coordinates and append them to the list of points
             const QJsonArray coords = value.toArray();
             before_last_x = last_x;
@@ -1303,12 +1338,12 @@ bool VibesGraphicsArrow::computeProjection(int dimX, int dimY)
         double dy = (before_last_y - last_y);
         double arrow_angle = atan2(dy, dx);
         double tip_angle = 160. * M_PI / 180.0;
-  
+
         double x = last_x;
         double y = last_y;
 
-         // tip (right)
-        tip << QPointF(x,  y);
+        // tip (right)
+        tip << QPointF(x, y);
         // (upper left)
         tip << QPointF(x - cos(tip_angle + arrow_angle) * tip_length,
                        y - sin(tip_angle + arrow_angle) * tip_length);
@@ -1333,6 +1368,7 @@ bool VibesGraphicsArrow::computeProjection(int dimX, int dimY)
 //
 // VibesGraphicsPie
 //
+
 bool VibesGraphicsPie::parseJsonGraphics(const QJsonObject &json)
 {
     // Now process shape-specific properties
@@ -1344,7 +1380,7 @@ bool VibesGraphicsPie::parseJsonGraphics(const QJsonObject &json)
 
         // VibesGraphicsPie has JSON type "arrow"
         if (type == "pie" && json.contains("center"))
-        {            
+        {
             QJsonArray center = json["center"].toArray();
             if (center.size() != 2) return false;
             if (json.contains("rho"))
@@ -1372,22 +1408,22 @@ bool VibesGraphicsPie::computeProjection(int dimX, int dimY)
     const QJsonObject & json = this->_json;
 
     // Get arrow color (or default if not specified)
-    const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    const QBrush & brush = vibesDefaults.brush(jsonValue("FaceColor"));
+    const QPen & pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
-    Q_ASSERT (json.contains("type"));
+    Q_ASSERT(json.contains("type"));
     // VibesGraphicsPie has JSON type "arrow"
-    Q_ASSERT ( json["type"].toString() == "pie" );
+    Q_ASSERT(json["type"].toString() == "pie");
     // "bounds" is a matrix
-    QJsonArray center =  json["center"].toArray();
-    QJsonArray rho =  json["rho"].toArray();
-    QJsonArray theta =  json["theta"].toArray();
+    QJsonArray center = json["center"].toArray();
+    QJsonArray rho = json["rho"].toArray();
+    QJsonArray theta = json["theta"].toArray();
 
-    Q_ASSERT ( rho[0].toDouble() >= 0);
-    Q_ASSERT ( rho[1].toDouble() >= rho[0].toDouble());
-    Q_ASSERT ( theta[1].toDouble() >= theta[0].toDouble());
+    Q_ASSERT(rho[0].toDouble() >= 0);
+    Q_ASSERT(rho[1].toDouble() >= rho[0].toDouble());
+    Q_ASSERT(theta[1].toDouble() >= theta[0].toDouble());
 
 
     // Body
@@ -1402,18 +1438,18 @@ bool VibesGraphicsPie::computeProjection(int dimX, int dimY)
         double theta_p = -theta[1].toDouble();
 
         // Angles are in degree and in clock-wise
-        double m1_x = cx + rho_m*std::cos(-theta_m*M_PI/180.0);
-        double m1_y = cy + rho_m*std::sin(-theta_m*M_PI/180.0);
+        double m1_x = cx + rho_m * std::cos(-theta_m * M_PI / 180.0);
+        double m1_y = cy + rho_m * std::sin(-theta_m * M_PI / 180.0);
 
-        double m4_x = cx + rho_p*std::cos(-theta_m*M_PI/180.0);
-        double m4_y = cy + rho_p*std::sin(-theta_m*M_PI/180.0);
+        double m4_x = cx + rho_p * std::cos(-theta_m * M_PI / 180.0);
+        double m4_y = cy + rho_p * std::sin(-theta_m * M_PI / 180.0);
 
         double dtheta = theta_p - theta_m;
 
         QPainterPath path(QPointF(m1_x, m1_y));
         path.lineTo(m4_x, m4_y);
-        path.arcTo(QRectF(QPointF(cx-rho_p,cy-rho_p),QPointF(cx+rho_p, cy+rho_p)), theta_m, dtheta);
-        path.arcTo(QRectF(QPointF(cx-rho_m,cy-rho_m),QPointF(cx+rho_m, cy+rho_m)), theta_p, -dtheta);
+        path.arcTo(QRectF(QPointF(cx - rho_p, cy - rho_p), QPointF(cx + rho_p, cy + rho_p)), theta_m, dtheta);
+        path.arcTo(QRectF(QPointF(cx - rho_m, cy - rho_m), QPointF(cx + rho_m, cy + rho_m)), theta_p, -dtheta);
 
         QGraphicsPathItem *graphics_path = new QGraphicsPathItem(path);
         graphics_path->setPen(pen);

--- a/viewer/vibesgraphicsitem.cpp
+++ b/viewer/vibesgraphicsitem.cpp
@@ -15,6 +15,8 @@
 #include <QJsonValue>
 
 #include <cmath>
+#include <iostream>
+using namespace std;
 
 // The only instance of VibesDefaults
 VibesDefaults VibesDefaults::_instance;
@@ -330,6 +332,9 @@ bool VibesGraphicsBox::parseJsonGraphics(const QJsonObject &json)
         // VibesGraphicsBox has JSON type "box"
         if (type == "box")
         {
+            cout << "type=box"<<endl;
+            QJsonDocument doc(json);
+            cout << "json: "<<doc.toJson().toStdString()<<endl;
             QJsonArray bounds = json["bounds"].toArray();
             // We need at least a 2-D box. Number of bounds has to be even.
             if (bounds.size() < 4 || bounds.size()%2 != 0)
@@ -339,8 +344,16 @@ bool VibesGraphicsBox::parseJsonGraphics(const QJsonObject &json)
             this->_nbDim = bounds.size() / 2;
 
             // Set graphical properties
-            this->setPen( vibesDefaults.pen( jsonValue("EdgeColor").toString() ) );
-            this->setBrush( vibesDefaults.brush( jsonValue("FaceColor").toString() ) );
+//            cout << "Avant setPen"<<endl;
+//            cout << "EdgeColor is Array: "<<jsonValue("EdgeColor").isArray()<<endl;
+//            cout << "EdgeColor.toString(): "<<jsonValue("EdgeColor").toString().toStdString()<<endl;
+            // Those seems to be called on NULL values
+            //this->setPen( vibesDefaults.pen2( jsonValue("EdgeColor")) );
+            //this->setPen( vibesDefaults.pen( jsonValue("EdgeColor").toString() ) );
+//            cout << "Avant setBrush"<<endl;
+//            cout << "FaceColor is Array: "<<jsonValue("FaceColor").isArray()<<endl;
+//            cout << "FaceColor.toString(): "<<jsonValue("FaceColor").toString().toStdString()<<endl;
+            //this->setBrush( vibesDefaults.brush( jsonValue("FaceColor").toString() ) );
 
             // Update successful
             return true;
@@ -354,10 +367,10 @@ bool VibesGraphicsBox::parseJsonGraphics(const QJsonObject &json)
 bool VibesGraphicsBox::computeProjection(int dimX, int dimY)
 {
     const QJsonObject & json = this->_json;
-
+    cout << "Compute Projection"<<endl;
     // Get shape color (or default if not specified)
     const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor").toString() );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor").toString() );
+    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor"));
 
     Q_ASSERT(json.contains("type"));
     Q_ASSERT(json["type"].toString() == "box");

--- a/viewer/vibesgraphicsitem.cpp
+++ b/viewer/vibesgraphicsitem.cpp
@@ -884,7 +884,7 @@ bool VibesGraphicsLine::computeProjection(int dimX, int dimY)
 
     // Get line color (or default if not specified)
     //const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor").toString() );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    QPen pen = vibesDefaults.pen( jsonValue("EdgeColor") );
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
@@ -906,6 +906,19 @@ bool VibesGraphicsLine::computeProjection(int dimX, int dimY)
     path.addPolygon(polygon);
     this->setPath(path);
     // Set graphics properties
+    // Handle lineStyle
+    if(json.contains("LineStyle"))
+    {
+        Q_ASSERT(json["LineStyle"].isString());
+        string style=json["LineStyle"].toString().toStdString();
+        pen.setStyle(vibesDefaults.styleToPenStyle(style));
+    }
+    // Handle lineStyle
+    if(json.contains("LineWidth"))
+    {
+        Q_ASSERT(json["LineWidth"].isDouble());
+        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+    }
     this->setPen(pen);
     //this->setBrush(brush);
 
@@ -954,8 +967,8 @@ bool VibesGraphicsPolygon::computeProjection(int dimX, int dimY)
     const QJsonObject & json = this->_json;
 
     // Get shape color (or default if not specified)
-    const QBrush & brush = vibesDefaults.brush( jsonValue("FaceColor") );
-    const QPen & pen = vibesDefaults.pen( jsonValue("EdgeColor") );
+    QBrush brush = vibesDefaults.brush( jsonValue("FaceColor") );
+    QPen pen = vibesDefaults.pen( jsonValue("EdgeColor") );
 
     Q_ASSERT(json.contains("type"));
     Q_ASSERT(json["type"].toString() == "polygon");
@@ -970,6 +983,21 @@ bool VibesGraphicsPolygon::computeProjection(int dimX, int dimY)
     this->setPolygon(polygon);
 
     // Update polygon color
+    
+    // Set graphics properties
+    // Handle lineStyle
+    if(json.contains("LineStyle"))
+    {
+        Q_ASSERT(json["LineStyle"].isString());
+        string style=json["LineStyle"].toString().toStdString();
+        pen.setStyle(vibesDefaults.styleToPenStyle(style));
+    }
+    // Handle lineStyle
+    if(json.contains("LineWidth"))
+    {
+        Q_ASSERT(json["LineWidth"].isDouble());
+        pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0),0));
+    }
     this->setPen(pen);
     this->setBrush(brush);
 

--- a/viewer/vibesgraphicsitem.cpp
+++ b/viewer/vibesgraphicsitem.cpp
@@ -1292,7 +1292,7 @@ bool VibesGraphicsArrow::computeProjection(int dimX, int dimY)
 
     // Get arrow color (or default if not specified)
     const QBrush & brush = vibesDefaults.brush(jsonValue("FaceColor"));
-    const QPen & pen = vibesDefaults.pen(jsonValue("EdgeColor"));
+    QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
@@ -1325,6 +1325,19 @@ bool VibesGraphicsArrow::computeProjection(int dimX, int dimY)
         QPainterPath path;
         path.addPolygon(line);
         QGraphicsPathItem *graphics_path = new QGraphicsPathItem(path);
+        // Handle lineStyle
+        if (json.contains("LineStyle"))
+        {
+            Q_ASSERT(json["LineStyle"].isString());
+            string style = json["LineStyle"].toString().toStdString();
+            pen.setStyle(vibesDefaults.styleToPenStyle(style));
+        }
+        // Handle lineStyle
+        if (json.contains("LineWidth"))
+        {
+            Q_ASSERT(json["LineWidth"].isDouble());
+            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
+        }
         graphics_path->setPen(pen);
         this->addToGroup(graphics_path);
     }
@@ -1355,6 +1368,19 @@ bool VibesGraphicsArrow::computeProjection(int dimX, int dimY)
                        y - sin(-tip_angle + arrow_angle) * tip_length);
 
         QGraphicsPolygonItem *graphics_tip = new QGraphicsPolygonItem(tip);
+        // Handle lineStyle
+        if (json.contains("LineStyle"))
+        {
+            Q_ASSERT(json["LineStyle"].isString());
+            string style = json["LineStyle"].toString().toStdString();
+            pen.setStyle(vibesDefaults.styleToPenStyle(style));
+        }
+        // Handle lineStyle
+        if (json.contains("LineWidth"))
+        {
+            Q_ASSERT(json["LineWidth"].isDouble());
+            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
+        }
         graphics_tip->setPen(pen);
         graphics_tip->setBrush(brush);
         this->addToGroup(graphics_tip);
@@ -1409,7 +1435,7 @@ bool VibesGraphicsPie::computeProjection(int dimX, int dimY)
 
     // Get arrow color (or default if not specified)
     const QBrush & brush = vibesDefaults.brush(jsonValue("FaceColor"));
-    const QPen & pen = vibesDefaults.pen(jsonValue("EdgeColor"));
+    QPen pen = vibesDefaults.pen(jsonValue("EdgeColor"));
 
     // Now process shape-specific properties
     // (we can only update properties of a shape, but mutation into another type is not supported)
@@ -1452,6 +1478,21 @@ bool VibesGraphicsPie::computeProjection(int dimX, int dimY)
         path.arcTo(QRectF(QPointF(cx - rho_m, cy - rho_m), QPointF(cx + rho_m, cy + rho_m)), theta_p, -dtheta);
 
         QGraphicsPathItem *graphics_path = new QGraphicsPathItem(path);
+        
+        // Handle lineStyle
+        if (json.contains("LineStyle"))
+        {
+            Q_ASSERT(json["LineStyle"].isString());
+            string style = json["LineStyle"].toString().toStdString();
+            pen.setStyle(vibesDefaults.styleToPenStyle(style));
+        }
+        // Handle lineStyle
+        if (json.contains("LineWidth"))
+        {
+            Q_ASSERT(json["LineWidth"].isDouble());
+            pen.setWidthF(std::fmax(json["LineWidth"].toDouble(0), 0));
+        }
+
         graphics_path->setPen(pen);
         graphics_path->setBrush(brush);
         this->addToGroup(graphics_path);

--- a/viewer/vibesgraphicsitem.h
+++ b/viewer/vibesgraphicsitem.h
@@ -120,6 +120,11 @@ public:
                 name=value.toString();
             }
         }
+        QColor c(name.toLower());
+        if(c.isValid())
+        {
+            return QBrush(c);
+        }
         return _brushes[name]; 
     }
     
@@ -142,6 +147,12 @@ public:
             {
                 name=value.toString();
             }
+        }
+        QColor c;
+        c.setNamedColor(name.toLower());
+        if(c.isValid())
+        {
+            return QPen(c,0);
         }
         return _pens[name];
     }

--- a/viewer/vibesgraphicsitem.h
+++ b/viewer/vibesgraphicsitem.h
@@ -13,10 +13,7 @@
 #include <QHash>
 #include <QPen>
 
-#include <iostream>
-using namespace std;
-
-// Singleton class to hold Vibes defaults and constants
+#// Singleton class to hold Vibes defaults and constants
 class VibesDefaults {
     QHash<QString, QBrush> _brushes;
     QHash<QString, QPen> _pens;
@@ -83,16 +80,35 @@ public:
             return QColor(r,g,b,a);
     }
     
-    const QBrush brush(const QJsonValue &value) const { 
+    static Qt::PenStyle styleToPenStyle(const std::string &style)
+    {
+        if(style=="--")
+        {
+            return Qt::DashLine;
+        }
+        if(style=="-.")
+        {
+            return Qt::DashDotLine;
+        }
+        if(style==":")
+        {
+            return Qt::DotLine;
+        }
+        if(style=="-..")
+        {
+            return Qt::DashDotDotLine;
+        }
+        return Qt::SolidLine;
+    }
+    
+    QBrush brush(const QJsonValue &value) const { 
         QString name;
         if(value.isArray())
         {
-            cout << "Brush isArray"<<endl;
             return QBrush(QJsonArrayToQColor(value.toArray()));
         }
         if(value.isString())
         {
-            cout << "brush is string: "<<value.toString().toStdString()<<endl;
             QString valString=value.toString();
             if(valString.contains(","))
             {
@@ -107,7 +123,7 @@ public:
         return _brushes[name]; 
     }
     
-    const QPen pen(const QJsonValue &value) const {
+    QPen pen(const QJsonValue &value) const {
         QString name;
         if(value.isArray())
         {
@@ -118,7 +134,6 @@ public:
             QString valString=value.toString();
             if(valString.contains(","))
             {
-                cout << valString.toStdString()<<"contains a ,"<<endl;
                 QStringList sl=value.toString().split(",");
             
                 return QPen(QJsonArrayToQColor(QJsonArray::fromStringList(sl)),0);

--- a/viewer/vibesgraphicsitem.h
+++ b/viewer/vibesgraphicsitem.h
@@ -4,6 +4,7 @@
 #include <QGraphicsItem>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QJsonArray>
 
 //#include <QBitArray>
 #include "vibesscene2d.h"
@@ -12,14 +13,123 @@
 #include <QHash>
 #include <QPen>
 
+#include <iostream>
+using namespace std;
+
 // Singleton class to hold Vibes defaults and constants
 class VibesDefaults {
     QHash<QString, QBrush> _brushes;
     QHash<QString, QPen> _pens;
 public:
     static const VibesDefaults & instance() { return _instance; }
-    const QBrush brush(const QString & name = QString()) const { return _brushes[name]; }
-    const QPen pen(const QString & name = QString()) const { return _pens[name]; }
+    
+    static const QColor QJsonArrayToQColor(const QJsonArray &l)
+    {
+        double r=0,g=0,b=0,a=255;
+        
+        bool ok;
+            if(l.size()>=1)
+            {
+                if(l[0].isString())
+                {
+                    r=l[0].toString().toDouble(&ok);
+                    r=ok?r:0;
+                }
+                else if(l[0].isDouble())
+                {
+                    r=l[0].toDouble(0);
+                }
+            }
+        
+        
+            if(l.size()>=2)
+            {
+                if(l[1].isString())
+                {
+                    g=l[1].toString().toDouble(&ok);
+                    g=ok?g:0;
+                }
+                else if(l[1].isDouble())
+                {
+                    g=l[1].toDouble(0);
+                }
+            }
+        
+            if(l.size()>=3)
+            {
+                if(l[2].isString())
+                {
+                    b=l[2].toString().toDouble(&ok);
+                    b=ok?b:0;
+                }
+                else if(l[2].isDouble())
+                {
+                    r=l[2].toDouble(0);
+                }
+            }
+        
+            if(l.size()>=4)
+            {
+                if(l[3].isString())
+                {
+                    a=l[3].toString().toDouble(&ok);
+                    a=ok?a:255;
+                }
+                else if(l[3].isDouble())
+                {
+                    a=l[3].toDouble(255);
+                }
+            }
+            return QColor(r,g,b,a);
+    }
+    
+    const QBrush brush(const QJsonValue &value) const { 
+        QString name;
+        if(value.isArray())
+        {
+            cout << "Brush isArray"<<endl;
+            return QBrush(QJsonArrayToQColor(value.toArray()));
+        }
+        if(value.isString())
+        {
+            cout << "brush is string: "<<value.toString().toStdString()<<endl;
+            QString valString=value.toString();
+            if(valString.contains(","))
+            {
+                QStringList sl=value.toString().split(",");
+                return QBrush(QJsonArrayToQColor(QJsonArray::fromStringList(sl)));
+            }
+            else
+            {
+                name=value.toString();
+            }
+        }
+        return _brushes[name]; 
+    }
+    
+    const QPen pen(const QJsonValue &value) const {
+        QString name;
+        if(value.isArray())
+        {
+            return QPen(QJsonArrayToQColor(value.toArray()),0);
+        }
+        if(value.isString())
+        {
+            QString valString=value.toString();
+            if(valString.contains(","))
+            {
+                cout << valString.toStdString()<<"contains a ,"<<endl;
+                QStringList sl=value.toString().split(",");
+            
+                return QPen(QJsonArrayToQColor(QJsonArray::fromStringList(sl)),0);
+            }
+            else
+            {
+                name=value.toString();
+            }
+        }
+        return _pens[name];
+    }
 private:
     VibesDefaults();
     static VibesDefaults _instance;


### PR DESCRIPTION
Adds long awaited:
- line styling and sizing : by properties : .."LineStyle",":","LineWidth",4.2... or by format "darkRed-..[blue]"
- all colors naming from http://www.w3.org/TR/SVG/types.html#ColorKeywords
- custom RGB/RGBA color setting : by properties : .."FaceColor",(vibes::RGBA){100,100,1,255}... or by format : "mediumslateblue-..[255,42,35,12]"

Are you OK with this format?

How would you like to specify a lineWidth in the format?
for example, to set a 12 width line with : style, blue edges, white face, possibilities are:
- "@12@:blue[white]" 
- "{12}:blue[white]
- ?? suggestions

Should we add a way to specify transparency for named colors in the format?

@dvinc @SimonRohou @ThomasLeMezo @msis @ClementAubry 