### PR TITLE
Travis CI: also compile on OS X platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ os:
  - linux
  - osx
 
-# Allow compilation failure with clang (Qt 5.0 headers generates errors with clang)
+# Exclude the clang on Linux combination: Qt 5.0 headers generates errors with clang
 matrix:
-  allow_failures:
+  exclude:
    - compiler: clang
+     os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 compiler:
  - gcc
-# - clang
+ - clang
 
 before_install:
  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-add-repository --yes ppa:ubuntu-sdk-team/ppa; fi
@@ -30,3 +30,8 @@ script: make
 os:
  - linux
  - osx
+
+# Allow compilation failure with clang (Qt 5.0 headers generates errors with clang)
+matrix:
+  allow_failures:
+   - compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,31 @@ language: cpp
 
 compiler:
  - gcc
+# - clang
 
 before_install:
- - sudo apt-add-repository --yes ppa:ubuntu-sdk-team/ppa
- - sudo apt-get update -qq > output
+ - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-add-repository --yes ppa:ubuntu-sdk-team/ppa; fi
+ - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update -qq > output; fi
+ - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install qt5 && export PATH=/usr/local/opt/qt5/bin:$PATH; fi
 
 install:
- - sudo apt-get install -qq qt5-default libqt5svg5-dev > output
+ - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -qq qt5-default libqt5svg5-dev > output; fi
 # 32 bit compatibility (since CMake is a 32 bit bin)
- - sudo apt-get install -qq libc6:i386
+ - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -qq libc6:i386; fi
 # Install CMake bin (32 bit)
- - wget -P /tmp http://www.cmake.org/files/v2.8/cmake-2.8.12.1-Linux-i386.sh
- - chmod +rx /tmp/cmake-2.8.12.1-Linux-i386.sh
- - sudo sh /tmp/cmake-2.8.12.1-Linux-i386.sh --prefix=/usr/local/ --exclude-subdir --skip-license
+ - if [ $TRAVIS_OS_NAME == linux ]; then wget -P /tmp http://www.cmake.org/files/v2.8/cmake-2.8.12.1-Linux-i386.sh; fi
+ - if [ $TRAVIS_OS_NAME == linux ]; then chmod +rx /tmp/cmake-2.8.12.1-Linux-i386.sh; fi
+ - if [ $TRAVIS_OS_NAME == linux ]; then sudo sh /tmp/cmake-2.8.12.1-Linux-i386.sh --prefix=/usr/local/ --exclude-subdir --skip-license; fi
 
 before_script:
  - cd viewer
  - mkdir build
  - cd build
+ - cmake --version
  - cmake ../
 
 script: make
+
+os:
+ - linux
+ - osx


### PR DESCRIPTION
Travis CI now complies on 3 configurations: Linux/gcc, OSX/gcc and OSX/clang. The Linux/clang configuration is not tested due to Qt5.0 incompatibility.