### PR TITLE
Packaging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,23 @@ VIBes consists in two parts:
 The use of a separate viewer application enables an easy set-up on every system. First, pre-built binaries of the VIBes viewer are provided for Windows, MacOS and Linux platforms (but you are free to build the viewer from sources). Then, the API consists only of a few files that have to be included in your program.
 
 ##Building from sources
+
 ###Linux
+
 You should have git, cmake, qt5 and its svg module installed. On a Debian-like distribution, you can install them via:
+
 ```bash
 sudo apt-get install qt5-default libqt5svg5-dev cmake git
 ```
+
 You can then clone the git repository:
+
 ```bash
 git clone https://github.com/ENSTABretagneRobotics/VIBES.git
 ```
+
 Move to the viewer sources directory, and build the sources:
+
 ```bash
 cd VIBES/viewer
 mkdir build && cd build
@@ -34,8 +41,13 @@ cmake -DCMAKE_INSTALL_PREFIX=distrib ..
 make
 make install
 ```
+
 If everything went well, a VIBes executable is now in the distrib folder.
+
 ###Windows
+
 TODO
+
 ###OSX
+
 TODO

--- a/viewer/CMakeLists.txt
+++ b/viewer/CMakeLists.txt
@@ -95,11 +95,9 @@ IF(APPLE)
     INSTALL(TARGETS ${VIBES_viewer_EXE} BUNDLE DESTINATION .)#${CMAKE_CURRENT_BINARY_DIR})
 
     # Copy API files
-    install(FILES ../client-api/C/vibes.h ../client-api/C/vibes.c DESTINATION "Vibes C")
-    install(DIRECTORY ../client-api/C/examples DESTINATION "Vibes C")
-
-    install(DIRECTORY ../client-api/C++/src DESTINATION "Vibes C++")
-    install(DIRECTORY ../client-api/C++/examples DESTINATION "Vibes C++")
+    add_library(VIBES STATIC ../client-api/C++/src/vibes.h ../client-api/C++/src/vibes.cpp)
+    install(TARGETS Vibes LIBRARY DESTINATION lib)
+    install(FILES ../client-api/C++/src/vibes.h DESTINATION include)
 
     # Setup DMG window appearance: background image, size and icon layout
     SET(CPACK_DMG_BACKGROUND_IMAGE ${CMAKE_CURRENT_SOURCE_DIR}/VIBes_DMG_bg/VIBes_DMG_bg.jpg)


### PR DESCRIPTION
This PR improves packaging of VIBES so that it can be more easily used by other C++ programs. It also removes a line in the `viewer/CMakeLists.txt` that referred to a non-existent examples directory.

Now, the installation process creates a static library named VIBES that can be linked with other C++ programs, and also places the corresponding `vibes.h` header in the standard `include` location.