### PR TITLE
Fix Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ VIBes consists in two parts:
 
 The use of a separate viewer application enables an easy set-up on every system. First, pre-built binaries of the VIBes viewer are provided for Windows, MacOS and Linux platforms (but you are free to build the viewer from sources). Then, the API consists only of a few files that have to be included in your program.
 
-##Building from sources
-###Linux
+## Building from sources
+### Linux
 You should have git, cmake, qt5 and its svg module installed. On a Debian-like distribution, you can install them via:
 ```bash
 sudo apt-get install qt5-default libqt5svg5-dev qtbase5-dev cmake git
@@ -35,7 +35,7 @@ make
 make install
 ```
 If everything went well, a VIBes executable is now in the distrib folder.
-###Windows
+### Windows
 TODO
-###OSX
+### OSX
 TODO


### PR DESCRIPTION
A space is neeed after the leading hashes, in order to have the headings recognized as such