### PR TITLE
Z value for drawing

### DIFF
--- a/client-api/C++/examples/all_commands.cpp
+++ b/client-api/C++/examples/all_commands.cpp
@@ -341,6 +341,34 @@ int main()
     VIBES_TEST( vibes::axisAuto() );
 
 
+    // Notes on ZValues:
+    // ZValues have to be seen as a tree structure:
+    // groups are drawn by ascending ZValue order 
+    // items with no groups are treated as groups (with only one item)
+    // in a group, items are drawn by ascending ZValue order
+    // In definitive, Qt looks at the lowest ZValue group (or solo item), then draws it or all its items by ascending ZValue order,
+    // then goes to the second lowest ZValue group, etc. 
+    // Default ZValue is 0
+
+    VIBES_TEST( vibes::newFigure("ZValues") );
+
+    VIBES_TEST( vibes::drawBox(-1,0.5,0,1,vibesParams("ZValue",5,"FaceColor","red","EdgeColor","black")) );
+    VIBES_TEST( vibes::drawBox(-0.5,0.7,-0.5,0.5,vibesParams("ZValue",4.9,"FaceColor","green","EdgeColor","black")) );
+
+    VIBES_TEST( vibes::newGroup("circles",vibesParams("ZValue",4.5)));
+    VIBES_TEST( vibes::drawCircle(0,0,1,vibesParams("ZValue",10,"FaceColor","yellow","EdgeColor","black","group","circles")) );
+    VIBES_TEST( vibes::drawCircle(0.8,0,0.5,vibesParams("ZValue",4,"FaceColor","cyan","EdgeColor","black","group","circles")) );
+
+    VIBES_TEST( vibes::newGroup("circles_behind",vibesParams("ZValue",0))); // lowest than "circle" Zvalue, so it is "hidden" behind
+    VIBES_TEST( vibes::drawCircle(0,0.05,1,vibesParams("ZValue",15,"FaceColor","red","EdgeColor","black","group","circles_behind")) );
+    VIBES_TEST( vibes::drawCircle(0.8,0.05,0.5,vibesParams("ZValue",4,"FaceColor","green","EdgeColor","black","group","circles_behind")) );
+
+    // ZValue is 0, so it is behind the red and green boxes (ZValue 5 and 4.9) and the "circles" group (ZValue 4.5)
+    // but in front of the "circles_behind" group (ZValue 0) because they have the same ZValue, and it was drawn last
+    VIBES_TEST( vibes::drawBox(0,0.8,0,0.8,vibesParams("FaceColor","blue","EdgeColor","black")) ); 
+    VIBES_TEST( vibes::axisAuto() );
+
+
     /*  vibes::Params p2 = vibesParams("action", "draw",
                            "figure", "fig_name",
                            "shape", vibesParams("LineWidth",5,

--- a/viewer/vibesgraphicsitem.cpp
+++ b/viewer/vibesgraphicsitem.cpp
@@ -100,7 +100,7 @@ QJsonValue VibesGraphicsItem::jsonValue(const QString& key) const
     {
         return json()[key];
     }
-        // Else, return the property from its parent group
+    // Else, return the property from its parent group
     else
     {
         const VibesGraphicsGroup* group = 0;
@@ -303,6 +303,11 @@ bool VibesGraphicsItem::parseJson(QJsonObject &json)
     if (json.contains("name") && json["name"].isString())
     {
         this->setName(json["name"].toString());
+    }
+
+    if (json.contains("ZValue") && json["ZValue"].isDouble())
+    {
+        this->setZValue(json["ZValue"].toDouble());
     }
 
     // LineStyle and LineWidth need no processing

--- a/viewer/vibesgraphicsitem.h
+++ b/viewer/vibesgraphicsitem.h
@@ -115,6 +115,7 @@ class VibesGraphicsItem
     QGraphicsItem * _qGraphicsItem;
     QString _name;
     int _dimX, _dimY;
+    double _zValue; // if item is in a group, the distinction is needed between global ZValue and "group" ZValue
 public:
     enum { VibesGraphicsItemType = QGraphicsItem::UserType,
            // Group of item
@@ -165,6 +166,11 @@ public:
     QString name() const { return _name; }
     void setName(QString name) { if (name != this->name()) { _name=name; if (scene()) scene()->setItemName(this, this->name()); } }
     VibesScene2D* scene() const { if (_qGraphicsItem) return static_cast<VibesScene2D*>( _qGraphicsItem->scene() ); else return 0;}
+
+    void setInitialZValue(double z) { _zValue = z; }
+    double initialZValue() const { return _zValue; }
+    void setZValue(qreal z) { if (_qGraphicsItem) _qGraphicsItem->setZValue(z); }
+    double zValue() const { if (_qGraphicsItem) return _qGraphicsItem->zValue(); else return 0.; }
 
     operator QGraphicsItem& () { Q_ASSERT(_qGraphicsItem!=0); return *_qGraphicsItem; }
     operator const QGraphicsItem& () const { Q_ASSERT(_qGraphicsItem!=0); return *_qGraphicsItem; }

--- a/viewer/vibesgraphicsitem.h
+++ b/viewer/vibesgraphicsitem.h
@@ -115,7 +115,6 @@ class VibesGraphicsItem
     QGraphicsItem * _qGraphicsItem;
     QString _name;
     int _dimX, _dimY;
-    double _zValue; // if item is in a group, the distinction is needed between global ZValue and "group" ZValue
 public:
     enum { VibesGraphicsItemType = QGraphicsItem::UserType,
            // Group of item
@@ -167,8 +166,6 @@ public:
     void setName(QString name) { if (name != this->name()) { _name=name; if (scene()) scene()->setItemName(this, this->name()); } }
     VibesScene2D* scene() const { if (_qGraphicsItem) return static_cast<VibesScene2D*>( _qGraphicsItem->scene() ); else return 0;}
 
-    void setInitialZValue(double z) { _zValue = z; }
-    double initialZValue() const { return _zValue; }
     void setZValue(qreal z) { if (_qGraphicsItem) _qGraphicsItem->setZValue(z); }
     double zValue() const { if (_qGraphicsItem) return _qGraphicsItem->zValue(); else return 0.; }
 


### PR DESCRIPTION
Explanations are in the all_commands.cpp : 

Default ZValue is 0

ZValues have to be seen as a tree structure:

- groups are drawn by ascending ZValue order 
- items with no groups are treated as groups (with only one item)
- in a group, items are drawn by ascending ZValue order

In definitive, Qt looks at the lowest ZValue group (or solo item), then draws it or all its items by ascending ZValue order,
then goes to the second lowest ZValue group, etc. 

The latest item to be drawn shows on top
